### PR TITLE
COL-1495, /asset page loads in smoother fashion

### DIFF
--- a/src/components/assets/Asset.vue
+++ b/src/components/assets/Asset.vue
@@ -1,16 +1,16 @@
 <template>
-  <div>
-    <BackToAssetLibrary :anchor="asset && `asset-${asset.id}`" :disabled="isLoading" />
-    <div v-if="!isLoading">
+  <div v-if="!isLoading">
+    <BackToAssetLibrary :anchor="`asset-${asset.id}`" :disabled="isLoading" />
+    <div>
       <AssetPageHeader :asset="asset" />
-      <div class="mt-3 pa-2">
-        <v-card outlined>
-          <v-card-text>
+      <v-card class="mt-3 pa-2" outlined>
+        <v-card-text>
+          <div class="asset-image-container">
             <AssetImage :asset="asset" :contain="true" :max-height="540" />
-            <AssetOverview :asset="asset" />
-          </v-card-text>
-        </v-card>
-      </div>
+          </div>
+          <AssetOverview :asset="asset" />
+        </v-card-text>
+      </v-card>
       <!--
       TODO: Will Activity-Timeline suffer the fate of the Impact Studio? I.e., will it go away?
       <AssetActivityTimeline :asset="asset" />
@@ -54,3 +54,9 @@ export default {
   }
 }
 </script>
+
+<style scoped>
+.asset-image-container {
+  height: 540px;
+}
+</style>

--- a/src/components/assets/AssetUpload.vue
+++ b/src/components/assets/AssetUpload.vue
@@ -58,9 +58,9 @@
           <v-col cols="6">
             <AccessibleSelect
               id-prefix="asset-category"
+              :items="categories"
               item-text="title"
               item-value="id"
-              :items="categories"
               label="What assignment or topic is this related to"
               :value="categoryId"
               @input="c => (categoryId = c)"

--- a/src/components/assets/AssetsHeader.vue
+++ b/src/components/assets/AssetsHeader.vue
@@ -89,13 +89,12 @@
               <v-row no-gutters>
                 <v-col class="pr-2">
                   <AccessibleSelect
-                    :clearable="true"
                     :dense="true"
                     :disabled="isBusy"
                     id-prefix="adv-search-categories"
+                    :items="categories"
                     item-text="title"
                     item-value="id"
-                    :items="categories"
                     label="Category"
                     :value="categoryId"
                     @input="setCategoryId"
@@ -103,7 +102,6 @@
                 </v-col>
                 <v-col>
                   <AccessibleSelect
-                    :clearable="true"
                     :dense="true"
                     :disabled="isBusy"
                     id-prefix="adv-search-asset-types"
@@ -117,14 +115,13 @@
               <v-row no-gutters>
                 <v-col class="w-50">
                   <AccessibleSelect
-                    :clearable="true"
                     class="w-50"
                     :dense="true"
                     :disabled="isBusy"
                     id-prefix="adv-search-user"
+                    :items="users"
                     item-text="canvasFullName"
                     item-value="id"
-                    :items="users"
                     label="User"
                     :value="userId"
                     @input="setUserId"

--- a/src/components/assets/EditAsset.vue
+++ b/src/components/assets/EditAsset.vue
@@ -34,12 +34,11 @@
             </div>
             <div>
               <AccessibleSelect
-                :clearable="true"
                 :dense="true"
                 id-prefix="asset-category"
+                :items="categories"
                 item-text="title"
                 item-value="id"
-                :items="categories"
                 label="Category"
                 :value="categoryId"
                 @input="c => (categoryId = c)"

--- a/src/components/util/AccessibleSelect.vue
+++ b/src/components/util/AccessibleSelect.vue
@@ -2,7 +2,7 @@
   <v-select
     :id="`${idPrefix}-select`"
     v-model="modelProxy"
-    :clearable="clearable"
+    :clearable="true"
     :dense="dense"
     :disabled="disabled"
     :eager="true"
@@ -27,10 +27,6 @@
 export default {
   name: 'AccessibleSelect',
   props: {
-    clearable: {
-      required: false,
-      type: Boolean
-    },
     dense: {
       required: false,
       type: Boolean


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1495

Lessen the herky-jerky load of `/asset`.  (And, accessible-select is always clearable.)