### PR TITLE
COL-1486, improved LTI launch setup, with work-in-progress test coverage

### DIFF
--- a/squiggy/api/auth_controller.py
+++ b/squiggy/api/auth_controller.py
@@ -23,12 +23,13 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from flask import current_app as app, request
+from flask import current_app as app, redirect, request
 from flask_login import current_user, login_required, login_user, logout_user
-from squiggy.lib.errors import ResourceNotFoundError
+from squiggy.lib.errors import ResourceNotFoundError, UnauthorizedRequestError
 from squiggy.lib.http import tolerant_jsonify
 from squiggy.lib.login_session import LoginSession
 from squiggy.lib.util import to_int
+from squiggy.merged.lti import lti_launch, TOOL_ID_ASSET_LIBRARY, TOOL_ID_ENGAGEMENT_INDEX
 
 
 @app.route('/api/auth/dev_auth_login', methods=['POST'])
@@ -57,3 +58,25 @@ def dev_auth_login():
 def logout():
     logout_user()
     return tolerant_jsonify(current_user.to_api_json())
+
+
+@app.route('/api/auth/lti_launch/asset_library', methods=['POST'])
+def lti_launch_asset_library():
+    return _lti_launch(TOOL_ID_ASSET_LIBRARY)
+
+
+@app.route('/api/auth/lti_launch/engagement_index', methods=['POST'])
+def lti_launch_engagement_index():
+    return _lti_launch(TOOL_ID_ENGAGEMENT_INDEX)
+
+
+def _lti_launch(tool_id):
+    user, redirect_path = lti_launch(request=request, tool_id=tool_id)
+    login_session = LoginSession(user and user.id)
+    login_user(login_session, force=True, remember=True)
+
+    if current_user.is_authenticated:
+        vue_base_url = app.config['VUE_LOCALHOST_BASE_URL']
+        return redirect(f"{vue_base_url or ''}{redirect_path}")
+    else:
+        raise UnauthorizedRequestError('Failed to identify user in LTI launch.')

--- a/squiggy/merged/lti_request_validator.py
+++ b/squiggy/merged/lti_request_validator.py
@@ -23,55 +23,30 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
-from squiggy.lib.util import is_admin, is_teaching
-from squiggy.models.user import User
+from oauthlib.oauth1 import RequestValidator
 
 
-class LoginSession:
+class LtiRequestValidator(RequestValidator):
 
-    user = None
+    def __init__(self, canvas):
+        super().__init__()
+        self.canvas = canvas
 
-    def __init__(self, user_id):
-        self.user = User.find_by_id(user_id) if user_id else None
-
-    def get_id(self):
-        return self.user and self.user.id
+    def get_client_secret(self, client_key, request):
+        return self.canvas.lti_secret
 
     @property
-    def canvas_course_role(self):
-        return self.user and self.user.canvas_course_role
+    def client_key_length(self):
+        return 20, 32
 
-    @property
-    def course(self):
-        return self.user and self.user.course
-
-    @property
-    def is_active(self):
-        return self.is_authenticated
-
-    @property
-    def is_admin(self):
-        return is_admin(self)
-
-    @property
-    def is_authenticated(self):
-        return self.user is not None
-
-    @property
-    def is_teaching(self):
-        return is_teaching(self)
-
-    @property
-    def user_id(self):
-        return self.user and self.user.id
-
-    def to_api_json(self):
-        return {
-            **(self.user.to_api_json() if self.user else {}),
-            **{
-                'course': self.course and self.course.to_api_json(),
-                'isAdmin': self.is_admin,
-                'isAuthenticated': self.is_authenticated,
-                'isTeaching': self.is_teaching,
-            },
-        }
+    def validate_timestamp_and_nonce(
+            self,
+            client_key,
+            timestamp,
+            nonce,
+            request,
+            request_token=None,
+            access_token=None,
+    ):
+        # TODO: RequestValidator requires that this subclass implement this method. For now, we skip this validation.
+        return True

--- a/squiggy/models/canvas.py
+++ b/squiggy/models/canvas.py
@@ -24,7 +24,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from dateutil.tz import tzutc
-from sqlalchemy import and_
 from squiggy import db
 from squiggy.models.base import Base
 
@@ -76,8 +75,8 @@ class Canvas(Base):
                 """
 
     @classmethod
-    def find_by_domain(cls, canvas_api_domain, lti_key):
-        return cls.query.filter(and_(cls.canvas_api_domain == canvas_api_domain, cls.lti_key == lti_key)).first()
+    def find_by_domain(cls, canvas_api_domain):
+        return cls.query.filter_by(canvas_api_domain=canvas_api_domain).first()
 
     @classmethod
     def get_all(cls):

--- a/squiggy/models/user.py
+++ b/squiggy/models/user.py
@@ -165,6 +165,10 @@ class User(Base):
         return cls.query.filter_by(course_id=course_id).order_by(cls.canvas_full_name).all()
 
     @classmethod
+    def find_by_canvas_user_id(cls, canvas_user_id):
+        return cls.query.filter_by(canvas_user_id=canvas_user_id).first()
+
+    @classmethod
     def find_by_id(cls, user_id):
         user_id = to_int(user_id)
         if not user_id:

--- a/src/components/engage/Engage.vue
+++ b/src/components/engage/Engage.vue
@@ -1,0 +1,14 @@
+<template>
+  <div>
+    How engaging are you?
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'Engage',
+  created() {
+    console.log('Foo')
+  }
+}
+</script>

--- a/src/router.ts
+++ b/src/router.ts
@@ -5,6 +5,7 @@ import Assets from '@/components/assets/Assets.vue'
 import AssetUpload from '@/components/assets/AssetUpload.vue'
 import BaseView from '@/components/BaseView.vue'
 import EditAsset from '@/components/assets/EditAsset.vue'
+import Engage from '@/components/engage/Engage.vue'
 import Error from '@/components/Error.vue'
 import ManageAssets from '@/components/assets/ManageAssets.vue'
 import NotFound from '@/components/NotFound.vue'
@@ -73,6 +74,13 @@ const router = new Router({
           component: EditAsset,
           meta: {
             title: 'Asset'
+          }
+        },
+        {
+          path: '/engage',
+          component: Engage,
+          meta: {
+            title: 'Engagement Index'
           }
         }
       ]

--- a/tests/test_api/test_canvas_controller.py
+++ b/tests/test_api/test_canvas_controller.py
@@ -32,11 +32,11 @@ class TestLtiCartridgeController:
         response = client.get('/lti/cartridge/asset_library.xml')
         assert response.status_code == 200
         assert 'application/xml' in response.content_type
-        assert '/assets' in str(response.data)
+        assert '/api/auth/lti_launch/asset_library' in str(response.data)
 
     def test_engagement_index_xml(self, client):
         """Valid cartridge XML contains Engagement Index launch URL."""
         response = client.get('/lti/cartridge/engagement_index.xml')
         assert response.status_code == 200
         assert 'application/xml' in response.content_type
-        assert '/engage' in str(response.data)
+        assert '/api/auth/lti_launch/engagement_index' in str(response.data)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1486

I believe this is a sensible setup, with dedicated LTI launch URL per `tool_id`. Simulating Canvas launch POST in our pytests is tricky – I've dropped in appropriate TODOs.