### PR TITLE
COL-1515, loosen validation rule on OAuth nonce value

### DIFF
--- a/squiggy/merged/lti_request_validator.py
+++ b/squiggy/merged/lti_request_validator.py
@@ -45,6 +45,10 @@ class LtiRequestValidator(RequestValidator):
     def client_key_length(self):
         return 20, 32
 
+    @property
+    def nonce_length(self):
+        return 20, 50
+
     def validate_timestamp_and_nonce(
             self,
             client_key,


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1515

My test on `ucberkeley.test.instructure.com` gave us real-world nonce value. Canvas gave us a 42 char string so I rounded up.