### PR TITLE
COL-1482, LTI launch redirect sends canvas_api_domain and canvas_course_id to client-side

### DIFF
--- a/squiggy/models/user.py
+++ b/squiggy/models/user.py
@@ -110,9 +110,9 @@ class User(Base):
             canvas_full_name,
             canvas_user_id,
             course_id,
-            canvas_image=None,
-            canvas_email=None,
             canvas_course_sections=None,
+            canvas_email=None,
+            canvas_image=None,
     ):
         user = cls(
             canvas_course_role=canvas_course_role,
@@ -129,36 +129,9 @@ class User(Base):
         return user
 
     @classmethod
-    def find_or_create(
-            cls,
-            canvas_course_role,
-            canvas_enrollment_state,
-            canvas_full_name,
-            canvas_user_id,
-            course_id,
-            canvas_course_sections=None,
-            canvas_email=None,
-            canvas_image=None,
-    ):
-        where_clause = and_(
-            cls.course_id == course_id,
-            cls.canvas_user_id == canvas_user_id,
-        )
-        user = cls.query.filter(where_clause).one_or_none()
-        if not user:
-            user = cls(
-                canvas_course_role=canvas_course_role,
-                canvas_course_sections=canvas_course_sections,
-                canvas_email=canvas_email,
-                canvas_enrollment_state=canvas_enrollment_state,
-                canvas_full_name=canvas_full_name,
-                canvas_image=canvas_image,
-                canvas_user_id=canvas_user_id,
-                course_id=course_id,
-            )
-            db.session.add(user)
-            std_commit()
-        return user
+    def find_by_course_id(cls, canvas_user_id, course_id):
+        where_clause = and_(cls.course_id == course_id, cls.canvas_user_id == canvas_user_id)
+        return cls.query.filter(where_clause).one_or_none()
 
     @classmethod
     def get_users_by_course_id(cls, course_id):

--- a/src/main.ts
+++ b/src/main.ts
@@ -57,11 +57,13 @@ Vue.config.errorHandler = function(error, vm, info) {
   })
 }
 
-if (Vue.prototype.$isInIframe) {
-  // We are in an iFrame. Grab course ID from Canvas context.
-  const e = document.getElementById('custom_canvas_course_id')
-  axios.defaults.headers['Squiggy-Canvas-Course-Id'] = _.get(e, 'value')
-}
+const params = new URLSearchParams(window.location.search)
+axios.defaults.headers['Squiggy-Canvas-Api-Domain'] = params.get('canvasApiDomain')
+axios.defaults.headers['Squiggy-Canvas-Course-Id'] = params.get('canvasCourseId')
+
+// TODO: Remove console logging when all is working well.
+console.log('canvasApiDomain = ' + params.get('canvasApiDomain'))
+console.log('canvasCourseId = ' + params.get('canvasCourseId'))
 
 axios.get(`${apiBaseUrl}/api/profile/my`).then(data => {
   Vue.prototype.$currentUser = data


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1482

And then the client sends `canvas_api_domain` and `canvas_course_id` as headers to `routes._user_loader`. This setup allows multiple browser tabs, across multiple course sites (same canvas-domain).