### PR TITLE
COL-1476, redirect to /asset if assetId found in URL during LTI launch

### DIFF
--- a/src/components/assets/Asset.vue
+++ b/src/components/assets/Asset.vue
@@ -50,6 +50,9 @@ export default {
     getAsset(this.$route.params.id).then(data => {
       this.asset = data
       this.$ready(this.asset.title)
+      if (this.$isInIframe) {
+        window.top.location.href = `${window.top.location.href}?assetId=${this.asset.id}`
+      }
     })
   }
 }

--- a/src/components/assets/AssetCard.vue
+++ b/src/components/assets/AssetCard.vue
@@ -19,7 +19,7 @@
         @click="go(`/asset/${asset.id}`)"
       >
         <v-sheet elevation="1">
-          <v-img class="thumbnail" :src="asset.thumbnailUrl || imgNotFound" @error="imgError(asset)">
+          <v-img class="thumbnail" :src="thumbnailUrl || imgNotFound" @error="imgError">
             <v-card-text class="asset-metadata">
               <div class="mb-3">
                 {{ asset.title }}
@@ -67,12 +67,15 @@ export default {
       type: Object
     }
   },
-  data: () => ({
-    imgNotFound: require('@/assets/img-not-found.png')
-  }),
+  data: function() {
+    return {
+      imgNotFound: require('@/assets/img-not-found.png'),
+      thumbnailUrl: this.asset.thumbnailUrl
+    }
+  },
   methods: {
-    imgError(asset) {
-      asset.thumbnailUrl = this.imgNotFound
+    imgError() {
+      this.thumbnailUrl = this.imgNotFound
     }
   }
 }


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1476

Review with `?w=1` for simple diff.  Doing param check on server-side (LTI launch) allows for test coverage. 