### PR TITLE
COL-1519 Get Flask session cookie working inside Chrome iframes

### DIFF
--- a/config/default.py
+++ b/config/default.py
@@ -76,6 +76,11 @@ S3_REGION = 'us-west-2'
 # Used to encrypt session cookie.
 SECRET_KEY = 'secret'
 
+# Required for session cookie to work inside iframes on Chrome.
+SESSION_COOKIE_HTTPONLY = False
+SESSION_COOKIE_SAMESITE = 'None'
+SESSION_COOKIE_SECURE = True
+
 # Save DB changes at the end of a request.
 SQLALCHEMY_COMMIT_ON_TEARDOWN = True
 

--- a/squiggy/api/auth_controller.py
+++ b/squiggy/api/auth_controller.py
@@ -65,7 +65,7 @@ def logout():
         f'{canvas_api_domain}_supports_custom_messaging',
     ]
     for key in keys:
-        response.set_cookie(key, '', expires=0)
+        response.set_cookie(key, '', samesite='None', secure=True, expires=0)
 
     logout_user()
     return response

--- a/squiggy/routes.py
+++ b/squiggy/routes.py
@@ -106,7 +106,7 @@ def register_routes(app):
             response.set_cookie(
                 key=f'{canvas_api_domain}|{canvas_course_id}',
                 value=str(current_user.user_id),
-                samesite=None,
+                samesite='None',
                 secure=True,
             )
         # TODO: Remove the above


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1519

Because the Flask session cookie was missing the "SameSite" attribute, Chrome wasn't persisting Flask sessions inside iframes. Generally this wasn't getting in the way of functionality because we have axios sending out magic `Squiggy-Canvas-Api-Domain` and `Squiggy-Canvas-Course-Id` headers that can substitute for the Flask session cookie. But axios can't handle file downloads, and calling an API URL directly from the browser didn't work.

@johncrossman, this might have implications for your recent work around LTI auth. Right now, in Chrome (but not in Firefox or Safari), because the Flask session cookie isn't being set in iframes, `user.is_authenticated` will always come back false server side, meaning it's continually referring to the magic-header logic in the `_user_loader` method. However, Firefox and Safari are seeing the cookie set so aren't doing the same. This PR should bring Chrome behavior in line with Safari and Firefox, but I'm not sure what the implications are for course sites in multiple tabs.