### PR TITLE
COL-1561 Per-thread logging for poller

### DIFF
--- a/squiggy/api/api_util.py
+++ b/squiggy/api/api_util.py
@@ -28,6 +28,7 @@ from functools import wraps
 from flask import current_app as app, request
 from flask_login import current_user
 from squiggy.lib.util import is_teaching
+from squiggy.logger import logger
 
 
 def teacher_required(func):
@@ -37,7 +38,7 @@ def teacher_required(func):
         if is_authorized:
             return func(*args, **kw)
         else:
-            app.logger.warning(f'Unauthorized request to {request.path}')
+            logger.warning(f'Unauthorized request to {request.path}')
             return app.login_manager.unauthorized()
     return _teacher_required
 

--- a/squiggy/api/error_handlers.py
+++ b/squiggy/api/error_handlers.py
@@ -26,6 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from flask import current_app as app
 import squiggy.lib.errors
 from squiggy.lib.http import tolerant_jsonify
+from squiggy.logger import logger
 
 
 @app.errorhandler(squiggy.lib.errors.BadRequestError)
@@ -55,5 +56,5 @@ def handle_internal_server_error(error):
 
 @app.errorhandler(Exception)
 def handle_unexpected_error(error):
-    app.logger.exception(error)
+    logger.exception(error)
     return tolerant_jsonify({'message': 'An unexpected server error occurred.'}), 500

--- a/squiggy/api/previews_controller.py
+++ b/squiggy/api/previews_controller.py
@@ -29,6 +29,7 @@ from flask import current_app as app, request
 from squiggy.lib.errors import BadRequestError, InternalServerError, UnauthorizedRequestError
 from squiggy.lib.http import tolerant_jsonify
 from squiggy.lib.previews import verify_preview_service_authorization
+from squiggy.logger import logger
 from squiggy.models.asset import Asset
 
 
@@ -45,8 +46,8 @@ def previews_callback():
         if params.get('metadata'):
             metadata = json.loads(params['metadata'])
     except Exception as e:
-        app.logger.error('Failed to parse JSON preview metadata.')
-        app.logger.exception(e)
+        logger.error('Failed to parse JSON preview metadata.')
+        logger.exception(e)
         raise BadRequestError('Could not parse JSON metadata.')
 
     asset = Asset.find_by_id(params['id'])

--- a/squiggy/api/status_controller.py
+++ b/squiggy/api/status_controller.py
@@ -28,6 +28,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from squiggy import db
 from squiggy.externals.canvas import ping_canvas
 from squiggy.lib.http import tolerant_jsonify
+from squiggy.logger import logger
 
 
 @app.route('/api/ping')
@@ -45,7 +46,7 @@ def _db_status():
         db.session.execute('SELECT 1')
         return True
     except SQLAlchemyError:
-        app.logger.exception('Database connection error')
+        logger.exception('Database connection error')
         return False
 
 
@@ -53,6 +54,6 @@ def _ping_canvas():
     try:
         return ping_canvas() if app.config['CANVAS_ACCESS_TOKEN'] else None
     except CanvasException as e:
-        app.logger.error('Canvas error during /api/ping')
-        app.logger.exception(e)
+        logger.error('Canvas error during /api/ping')
+        logger.exception(e)
         return False

--- a/squiggy/factory.py
+++ b/squiggy/factory.py
@@ -29,7 +29,7 @@ from flask import Flask
 from squiggy import db
 from squiggy.configs import load_configs
 from squiggy.lib.canvas_poller import launch_pollers
-from squiggy.logger import initialize_logger
+from squiggy.logger import initialize_app_logger
 from squiggy.routes import register_routes
 
 
@@ -37,7 +37,7 @@ def create_app():
     """Initialize app with configs."""
     app = Flask(__name__.split('.')[0])
     load_configs(app)
-    initialize_logger(app)
+    initialize_app_logger(app)
     db.init_app(app)
 
     with app.app_context():

--- a/squiggy/lib/aws.py
+++ b/squiggy/lib/aws.py
@@ -30,6 +30,7 @@ from urllib.parse import parse_qs, urlparse
 import boto3
 from flask import current_app as app
 import smart_open
+from squiggy.logger import logger
 
 
 S3_PREVIEW_URL_PATTERN = re.compile('^https://suitec-preview-images-\w+\.s3.*\.amazonaws\.com')
@@ -65,8 +66,8 @@ def put_binary_data_to_s3(bucket, key, binary_data, content_type):
         s3.put_object(Body=binary_data, Bucket=bucket, Key=key, ContentType=content_type)
         return True
     except Exception as e:
-        app.logger.error(f'S3 put operation failed (bucket={bucket}, key={key})')
-        app.logger.exception(e)
+        logger.error(f'S3 put operation failed (bucket={bucket}, key={key})')
+        logger.exception(e)
         return None
 
 
@@ -74,8 +75,8 @@ def stream_object(s3_url):
     try:
         return smart_open.open(s3_url, 'rb', transport_params={'session': _get_session()})
     except Exception as e:
-        app.logger.error(f'S3 stream operation failed (s3_url={s3_url})')
-        app.logger.exception(e)
+        logger.error(f'S3 stream operation failed (s3_url={s3_url})')
+        logger.exception(e)
         return None
 
 

--- a/squiggy/lib/http.py
+++ b/squiggy/lib/http.py
@@ -27,9 +27,10 @@ import csv
 from datetime import datetime
 import urllib
 
-from flask import current_app as app, Response
+from flask import Response
 import requests
 import simplejson as json
+from squiggy.logger import logger
 from werkzeug.wrappers import ResponseStream
 
 
@@ -61,14 +62,14 @@ def request(url, headers={}, method='get', **kwargs):
     """
     if method not in ['get', 'post', 'put', 'delete']:
         raise ValueError(f'Unrecognized HTTP method "{method}"')
-    app.logger.debug({'message': 'HTTP request', 'url': url, 'method': method, 'headers': sanitize_headers(headers)})
+    logger.debug({'message': 'HTTP request', 'url': url, 'method': method, 'headers': sanitize_headers(headers)})
     response = None
     try:
         http_method = getattr(requests, method)
         response = http_method(url, headers=headers, **kwargs)
         response.raise_for_status()
     except requests.exceptions.RequestException as e:
-        app.logger.error(e)
+        logger.error(e)
         return ResponseExceptionWrapper(e, response)
     else:
         return response

--- a/squiggy/lib/previews.py
+++ b/squiggy/lib/previews.py
@@ -32,6 +32,7 @@ import re
 from flask import current_app as app
 from squiggy.lib import http
 from squiggy.lib.util import to_int
+from squiggy.logger import logger
 
 
 S3_PREVIEW_URL_PATTERN = re.compile(r'^https://suitec-preview-images-\w+\.s3.*\.amazonaws\.com')
@@ -51,7 +52,7 @@ def generate_previews(asset_id, asset_url):
         },
     )
     if not response:
-        app.logger.error(f'Error generating previews (asset_id={asset_id}, asset_url={asset_url}.')
+        logger.error(f'Error generating previews (asset_id={asset_id}, asset_url={asset_url}.')
     return response
 
 
@@ -64,22 +65,22 @@ def generate_preview_service_signature(nonce=None):
 
 def verify_preview_service_authorization(auth_header):
     if not (auth_header and auth_header.startswith('Bearer ')):
-        app.logger.error('No authorization token provided to preview service callback.')
+        logger.error('No authorization token provided to preview service callback.')
         return False
 
     header_fields = auth_header[7:].split(':', 1)
     if len(header_fields) != 2:
-        app.logger.error('Invalid authorization token provided to preview service callback.')
+        logger.error('Invalid authorization token provided to preview service callback.')
         return False
 
     nonce = to_int(header_fields[0]) or 0
     now = int(datetime.now().timestamp() * 1000)
     if abs(now - nonce) > (600 * 1000):
-        app.logger.error(f'Invalid authorization nonce provided to preview service callback: {nonce}.')
+        logger.error(f'Invalid authorization nonce provided to preview service callback: {nonce}.')
         return False
 
     if generate_preview_service_signature(str(nonce)) != auth_header:
-        app.logger.error(f'Invalid authorization signature provided to preview service callback: {nonce}.')
+        logger.error(f'Invalid authorization signature provided to preview service callback: {nonce}.')
         return False
 
     return True


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1561

With one or more poller threads running per Canvas instance, we will suffer chaos and torment if we don't separate out the logging. Foreground app activity still goes to `squiggy.log`, but poller threads now log to filenames of the form `poller_0_ucberkeley.beta.instructure.com.log`, `poller_1_ucberkeley.test.instructure.com.log`, etc.