### PR TITLE
COL-1539 Follow-up for iframe context

### DIFF
--- a/src/router.ts
+++ b/src/router.ts
@@ -53,8 +53,8 @@ const router = new Router({
         },
         {
           beforeEnter: (to: any, from: any, next: any) => {
-            // Skip hash redirect if we're returning from an already-hashed asset page.
-            if (from.fullPath.match(/\/asset\/\d+#suitec_assetId/)) {
+            // Skip hash redirect if we're returning from an asset page.
+            if (from.fullPath.match(/\/asset\/\d+/)) {
               next()
             } else {
               store.dispatch('context/loadingStart')


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1539

Follow-up to #159; we have to loosen the path matching since asset paths don't get hashed inside the iframe.