### PR TITLE
COL-1487 Remove Flask-Cors package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,5 @@
 boto3==1.17.24
 canvasapi==2.1.0
-Flask-Cors==3.0.10
 Flask-Login==0.5.0
 Flask-SQLAlchemy==2.5.1
 Flask==1.1.2

--- a/squiggy/api/category_controller.py
+++ b/squiggy/api/category_controller.py
@@ -24,7 +24,6 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from flask import current_app as app, request
-from flask_cors import cross_origin
 from flask_login import current_user, login_required
 from squiggy.api.api_util import teacher_required
 from squiggy.lib.errors import BadRequestError
@@ -61,7 +60,6 @@ def create_category():
 
 @app.route('/api/category/<category_id>/delete', methods=['DELETE'])
 @teacher_required
-@cross_origin(allow_headers=['Content-Type'])
 def delete(category_id):
     Category.delete(category_id)
     return tolerant_jsonify({'message': f'Category {category_id} deleted'}), 200


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1487

We originally added this to the mix in BOA (https://github.com/ets-berkeley-edu/boac/pull/1041) to allow DELETE requests on localhost; strangely, with Squiggy's header-based auth it seems to have the opposite effect, blocking DELETE requests on localhost. It started working once I took the package out.