### PR TITLE
COL-1589 No duplicate keyboard actions in delete comment dialog

### DIFF
--- a/src/components/assets/comments/DeleteCommentDialog.vue
+++ b/src/components/assets/comments/DeleteCommentDialog.vue
@@ -25,7 +25,7 @@
                 id="confirm-delete-btn"
                 color="primary"
                 @click="deleteConfirmed"
-                @keypress.enter="deleteConfirmed"
+                @keypress.enter.prevent="deleteConfirmed"
               >
                 Confirm
               </v-btn>
@@ -34,7 +34,7 @@
               <v-btn
                 id="cancel-delete-btn"
                 @click="cancelDelete"
-                @keypress.enter="cancelDelete"
+                @keypress.enter.prevent="cancelDelete"
               >
                 Cancel
               </v-btn>


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1589

I think some of the duplication between click and keyboard actions might be browser-dependent, but `prevent` seems to keep the wires from getting crossed.