### PR TITLE
COL-1627, upgrade to flake8 3.9.2 and fix lint-py errors

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ https://github.com/python-cas/python-cas/archive/master.zip
 # For testing
 
 moto==2.0.2
-pytest==6.2.2
+pytest==6.2.4
 pytest-flask==1.2.0
-responses==0.13.1
-tox==3.23.0
+responses==0.13.3
+tox==3.23.1

--- a/squiggy/lib/errors.py
+++ b/squiggy/lib/errors.py
@@ -26,7 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 from squiggy.lib.http import tolerant_jsonify
 
 
-class JsonableException(Exception):
+class JsonableError(Exception):
     def __init__(self, message):
         Exception.__init__(self)
         self.message = message
@@ -38,21 +38,21 @@ class JsonableException(Exception):
             return ''
 
 
-class BadRequestError(JsonableException):
+class BadRequestError(JsonableError):
     pass
 
 
-class UnauthorizedRequestError(JsonableException):
+class UnauthorizedRequestError(JsonableError):
     pass
 
 
-class ForbiddenRequestError(JsonableException):
+class ForbiddenRequestError(JsonableError):
     pass
 
 
-class ResourceNotFoundError(JsonableException):
+class ResourceNotFoundError(JsonableError):
     pass
 
 
-class InternalServerError(JsonableException):
+class InternalServerError(JsonableError):
     pass

--- a/tox.ini
+++ b/tox.ini
@@ -30,18 +30,18 @@ commands = pytest {posargs: -p no:warnings tests}
 # Bottom of file has Flake8 settings
 commands = flake8 {posargs:application.py config consoler.py scripts squiggy tests}
 deps =
-    flake8>=3.7.9
-    flake8-builtins>=1.4.2
-    flake8-colors>=0.1.6
+    flake8>=3.9.2
+    flake8-builtins>=1.5.3
+    flake8-colors>=0.1.9
     flake8-commas>=2.0.0
     flake8-docstrings>=1.5.0
     flake8-import-order>=0.18.1
     flake8-pytest>=1.3
-    flake8-quotes>=2.1.1
+    flake8-quotes>=3.2.0
     flake8-strict>=0.2.1
-    flake8-tidy-imports>=3.1.0
-    pep8-naming>=0.9.1
-    pydocstyle>=5.0.1
+    flake8-tidy-imports>=4.3.0
+    pep8-naming>=0.12.0
+    pydocstyle>=6.1.1
 
 [flake8]
 exclude =


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1627