### PR TITLE
COL-1628, Roll Squiggy back to Flask 1.x because pip install is stuck in AWS CodeBuild-land

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.17.24
 canvasapi==2.1.0
 Flask-Login==0.5.0
 Flask-SQLAlchemy==2.5.1
-Flask==2.0.1
+Flask==1.1.2
 lti==0.9.5
 oauthlib==3.1.0
 psycopg2-binary==2.8.6
@@ -12,7 +12,7 @@ pytz==2021.1
 simplejson==3.17.2
 smart-open==4.2.0
 SQLAlchemy==1.3.23
-Werkzeug==2.0.1
+Werkzeug==1.0.1
 https://github.com/python-cas/python-cas/archive/master.zip
 
 # For testing


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1628

