### PR TITLE
COL-1640 Auth protection for profile and config endpoints

### DIFF
--- a/squiggy/api/config_controller.py
+++ b/squiggy/api/config_controller.py
@@ -26,12 +26,14 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import json
 
 from flask import current_app as app
+from flask_login import login_required
 from squiggy import __version__ as version
 from squiggy.lib.http import tolerant_jsonify
 from squiggy.models.asset import assets_sort_by_options, assets_type
 
 
 @app.route('/api/config')
+@login_required
 def app_config():
     return tolerant_jsonify({
         'assetTypes': assets_type.enums,

--- a/squiggy/api/user_controller.py
+++ b/squiggy/api/user_controller.py
@@ -31,6 +31,7 @@ from squiggy.models.user import User
 
 
 @app.route('/api/profile/my')
+@login_required
 def my_profile():
     return tolerant_jsonify(current_user.to_api_json())
 

--- a/tests/test_api/test_config_controller.py
+++ b/tests/test_api/test_config_controller.py
@@ -28,7 +28,13 @@ class TestConfigController:
     """Config API."""
 
     def test_anonymous(self, client):
-        """Returns a well-formed response to anonymous user."""
+        """Denies anonymous user."""
+        response = client.get('/api/config')
+        assert response.status_code == 401
+
+    def test_logged_in(self, client, fake_auth, authorized_user_id):
+        """Returns a well-formed response to logged-in user."""
+        fake_auth.login(authorized_user_id)
         response = client.get('/api/config')
         assert response.status_code == 200
         assert 'squiggyEnv' in response.json

--- a/tests/test_api/test_user_controller.py
+++ b/tests/test_api/test_user_controller.py
@@ -47,6 +47,10 @@ def _api_update_share_points(client, data, expected_status_code=200):
 
 class TestMyProfile:
 
+    def test_anonymous(self, client):
+        """Denies anonymous user."""
+        _api_my_profile(client, expected_status_code=401)
+
     def test_admin_profile(self, client, fake_auth, authorized_user_id):
         fake_auth.login(authorized_user_id)
         api_json = _api_my_profile(client)


### PR DESCRIPTION
https://jira.ets.berkeley.edu/jira/browse/COL-1640

Reopen of #226 with front-end code added to handle auth failures in standalone mode. Next up: front-end handling for auth failures in LTI.