### PR TITLE
COL-1769, rename whiteboard_elements column: uid -> uuid

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .idea
 .vscode
 .history
+*.code-workspace
 
 # AWS
 .elasticbeanstalk/*

--- a/scripts/db/drop_schema.sql
+++ b/scripts/db/drop_schema.sql
@@ -134,7 +134,7 @@ DROP INDEX IF EXISTS asset_categories_category_id_idx;
 DROP INDEX IF EXISTS asset_users_asset_id_idx;
 DROP INDEX IF EXISTS asset_users_user_id_idx;
 
-DROP INDEX IF EXISTS whiteboard_elements_created_at_uid_whiteboard_id_idx;
+DROP INDEX IF EXISTS whiteboard_elements_created_at_uuid_whiteboard_id_idx;
 
 --
 

--- a/scripts/db/schema.sql
+++ b/scripts/db/schema.sql
@@ -177,7 +177,7 @@ CREATE INDEX asset_users_user_id_idx ON asset_users USING btree (user_id);
 --
 
 CREATE TABLE asset_whiteboard_elements (
-    uid character varying(255) NOT NULL,
+    uuid character varying(255) NOT NULL,
     element json NOT NULL,
     created_at timestamp with time zone NOT NULL,
     updated_at timestamp with time zone NOT NULL,
@@ -186,7 +186,7 @@ CREATE TABLE asset_whiteboard_elements (
 );
 
 ALTER TABLE ONLY asset_whiteboard_elements
-    ADD CONSTRAINT asset_whiteboard_elements_pkey PRIMARY KEY (uid, asset_id);
+    ADD CONSTRAINT asset_whiteboard_elements_pkey PRIMARY KEY (uuid, asset_id);
 
 --
 
@@ -381,7 +381,7 @@ ALTER TABLE ONLY users
 
 CREATE TABLE whiteboard_elements (
     id integer NOT NULL,
-    uid character varying(255) NOT NULL,
+    uuid character varying(255) NOT NULL,
     element json NOT NULL,
     whiteboard_id integer NOT NULL,
     asset_id integer,
@@ -398,7 +398,7 @@ CREATE SEQUENCE whiteboard_elements_id_seq
 ALTER SEQUENCE whiteboard_elements_id_seq OWNED BY whiteboard_elements.id;
 ALTER TABLE ONLY whiteboard_elements ALTER COLUMN id SET DEFAULT nextval('whiteboard_elements_id_seq'::regclass);
 
-CREATE UNIQUE INDEX whiteboard_elements_created_at_uid_whiteboard_id_idx ON whiteboard_elements USING btree (uid, whiteboard_id, created_at);
+CREATE UNIQUE INDEX whiteboard_elements_created_at_uuid_whiteboard_id_idx ON whiteboard_elements USING btree (uuid, whiteboard_id, created_at);
 
 --
 

--- a/scripts/migrate/2022/20220310-COL-1769/rename_whiteboard_elements_uid_column.sql
+++ b/scripts/migrate/2022/20220310-COL-1769/rename_whiteboard_elements_uid_column.sql
@@ -1,0 +1,13 @@
+BEGIN;
+
+ALTER TABLE asset_whiteboard_elements DROP CONSTRAINT asset_whiteboard_elements_pkey;
+ALTER TABLE asset_whiteboard_elements RENAME COLUMN uid TO uuid;
+ALTER TABLE ONLY asset_whiteboard_elements
+  ADD CONSTRAINT asset_whiteboard_elements_pkey PRIMARY KEY (uuid, asset_id);
+
+DROP INDEX IF EXISTS whiteboard_elements_created_at_uid_whiteboard_id_idx;
+ALTER TABLE whiteboard_elements RENAME COLUMN uid TO uuid;
+CREATE UNIQUE INDEX whiteboard_elements_created_at_uuid_whiteboard_id_idx
+  ON whiteboard_elements USING btree (uuid, whiteboard_id, created_at);
+
+COMMIT;

--- a/squiggy/api/whiteboard_element_controller.py
+++ b/squiggy/api/whiteboard_element_controller.py
@@ -46,7 +46,7 @@ def create_whiteboard_elements():
         raise BadRequestError('One or more whiteboard-elements required')
     if not can_update_whiteboard(user=current_user, whiteboard=whiteboard):
         raise BadRequestError('To update a whiteboard you must own it or be a teacher in the course.')
-    if _has_canvas(whiteboard_elements) and _has_canvas(whiteboard['elements']):
+    if _has_canvas(whiteboard_elements) and _has_canvas(whiteboard['whiteboardElements']):
         raise BadRequestError('Whiteboard can have one, and only one, element of type canvas.')
 
     api_json = []

--- a/squiggy/models/asset_whiteboard_element.py
+++ b/squiggy/models/asset_whiteboard_element.py
@@ -36,19 +36,19 @@ class AssetWhiteboardElement(Base):
     asset_id = db.Column(Integer, ForeignKey('assets.id'), primary_key=True)
     element = db.Column(JSONB, nullable=False)
     element_asset_id = db.Column(Integer, ForeignKey('assets.id'))
-    uid = db.Column(db.String(255), nullable=False, primary_key=True)
+    uuid = db.Column(db.String(255), nullable=False, primary_key=True)
 
     def __init__(
             self,
             element,
-            uid,
+            uuid,
             asset_id=None,
             element_asset_id=None,
     ):
         self.asset_id = asset_id
         self.element = element
         self.element_asset_id = element_asset_id
-        self.uid = uid
+        self.uuid = uuid
 
     @classmethod
     def create(cls, asset_id, whiteboard_elements):
@@ -57,7 +57,7 @@ class AssetWhiteboardElement(Base):
                 asset_id=asset_id,
                 element=whiteboard_element.element,
                 element_asset_id=whiteboard_element.asset_id,
-                uid=whiteboard_element.uid,
+                uuid=whiteboard_element.uuid,
             )
             db.session.add(asset_whiteboard_element)
         std_commit()
@@ -71,5 +71,5 @@ class AssetWhiteboardElement(Base):
             'assetId': self.asset_id,
             'element': self.element,
             'elementAssetId': self.element_asset_id,
-            'uid': self.uid,
+            'uuid': self.uuid,
         }

--- a/squiggy/models/whiteboard_element.py
+++ b/squiggy/models/whiteboard_element.py
@@ -38,31 +38,27 @@ class WhiteboardElement(Base):
     id = db.Column(db.Integer, nullable=False, primary_key=True)  # noqa: A003
     asset_id = db.Column('asset_id', Integer, ForeignKey('assets.id'))
     element = db.Column('element', JSONB, nullable=False)
-    uid = db.Column('uid', db.String(255), nullable=False)
+    uuid = db.Column('uuid', db.String(255), nullable=False)
     whiteboard_id = db.Column('whiteboard_id', Integer, ForeignKey('whiteboards.id'), nullable=False)
 
     __table_args__ = (db.UniqueConstraint(
         'created_at',
-        'uid',
+        'uuid',
         'whiteboard_id',
-        name='whiteboard_elements_created_at_uid_whiteboard_id_idx',
+        name='whiteboard_elements_created_at_uuid_whiteboard_id_idx',
     ),)
 
     def __init__(
             self,
             asset_id,
             element,
-            uid,
+            uuid,
             whiteboard_id,
     ):
         self.asset_id = asset_id
         self.element = element
-        self.uid = uid
+        self.uuid = uuid
         self.whiteboard_id = whiteboard_id
-
-    @classmethod
-    def find_by_uid(cls, uid):
-        return cls.query.filter_by(uid=uid).first()
 
     @classmethod
     def find_by_whiteboard_id(cls, whiteboard_id):
@@ -73,7 +69,7 @@ class WhiteboardElement(Base):
         asset_whiteboard_element = cls(
             asset_id=asset_id,
             element=element,
-            uid=str(uuid.uuid4()),
+            uuid=str(uuid.uuid4()),
             whiteboard_id=whiteboard_id,
         )
         db.session.add(asset_whiteboard_element)
@@ -94,7 +90,7 @@ class WhiteboardElement(Base):
             'assetId': self.asset_id,
             'createdAt': isoformat(self.created_at),
             'element': self.element,
-            'uid': self.uid,
             'updatedAt': isoformat(self.updated_at),
+            'uuid': self.uuid,
             'whiteboardId': self.whiteboard_id,
         }

--- a/src/api/whiteboards.ts
+++ b/src/api/whiteboards.ts
@@ -49,8 +49,8 @@ export function updateWhiteboard(title: string, whiteboardId: number) {
 
 export function updateWhiteboardElement(
   key: string,
-  uid: string,
+  uuid: string,
   value: any,
 ) {
-  return axios.post(`${utils.apiBaseUrl()}/api/whiteboard/element/update`, {key, uid, value})
+  return axios.post(`${utils.apiBaseUrl()}/api/whiteboard/element/update`, {key, uuid, value})
 }

--- a/src/components/util/DevAuth.vue
+++ b/src/components/util/DevAuth.vue
@@ -10,7 +10,7 @@
     <v-card color="transparent" flat width="360">
       <v-form @submit="devAuth">
         <v-text-field
-          id="uid-input"
+          id="user-id-input"
           v-model="userId"
           outlined
           placeholder="User ID"

--- a/src/components/whiteboards/toolbar/AddAssetsTool.vue
+++ b/src/components/whiteboards/toolbar/AddAssetsTool.vue
@@ -157,7 +157,8 @@ export default {
         this.isSaving = true
         const whiteboardElements = this.$_.map(this.selectedAssetIds, assetId => ({
           assetId,
-          element: {}
+          element: {},
+          whiteboardId: this.board.id
         }))
         this.saveWhiteboardElements(whiteboardElements).then(() => {
           this.$announcer.polite('Assets added')

--- a/src/store/whiteboarding.ts
+++ b/src/store/whiteboarding.ts
@@ -5,7 +5,7 @@ const defaultFabricElementBase = {
   fill: 'rgb(0,0,0)'
 }
 
-const $_findElement = (state: any, uid: number) => _.find(state.board.whiteboardElements, ['uid', uid])
+const $_findElement = (state: any, uuid: number) => _.find(state.board.whiteboardElements, ['uuid', uuid])
 
 const state = {
   board: undefined,
@@ -72,8 +72,8 @@ const mutations = {
 }
 
 const actions = {
-  getObjectAttribute: ({state}, {key, uid}) => {
-    const object = $_findElement(state, uid)
+  getObjectAttribute: ({state}, {key, uuid}) => {
+    const object = $_findElement(state, uuid)
     return object && object.get(key)
   },
   init: ({commit, state}, whiteboardId: number) => {
@@ -91,7 +91,11 @@ const actions = {
           done()
         } else {
           return createWhiteboardElements(
-            [state.fabricElementTemplates.canvas],
+            [{
+              assetId: undefined,
+              element: state.fabricElementTemplates.canvas,
+              whiteboardId: state.board.id
+            }],
             state.board.id
           ).then(data => _.get(data, 'element')).then(done)
         }

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -79,7 +79,7 @@ class TestDevAuth:
             )
 
     def test_authorized_user_fail(self, app, client):
-        """Fails if the chosen UID does not match an authorized user."""
+        """Fails if the chosen user_id does not match an authorized user."""
         with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
             self._api_dev_auth_login(
                 client,
@@ -89,7 +89,7 @@ class TestDevAuth:
             )
 
     def test_unauthorized_user(self, app, client):
-        """Fails if the chosen UID does not match an authorized user."""
+        """Fails if the chosen user_id does not match an authorized user."""
         with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
             self._api_dev_auth_login(
                 client,

--- a/tests/test_models/test_user.py
+++ b/tests/test_models/test_user.py
@@ -35,10 +35,10 @@ class TestUser:
     """User model."""
 
     def test_load_unknown_user(self):
-        """Returns None to Flask-Login for unrecognized UID."""
+        """Returns None to Flask-Login for unrecognized user_id."""
         assert User.find_by_id(unauthorized_user_id) is None
 
     def test_load_admin_user(self, authorized_user_id):
-        """Returns authorization record to Flask-Login for recognized UID."""
+        """Returns authorization record to Flask-Login for recognized user_id."""
         loaded_user = User.find_by_id(authorized_user_id)
         assert loaded_user.id == authorized_user_id


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1769

`uid` column name was inherited from old SuiteC and was documented as "unique whiteboard [fabric] element id".  A "universally unique identifier" should be named `uuid`.