### PR TITLE
COL-1775, API does the right thing with deleted whiteboards

### DIFF
--- a/squiggy/api/whiteboard_controller.py
+++ b/squiggy/api/whiteboard_controller.py
@@ -45,7 +45,7 @@ from squiggy.models.whiteboard_session import WhiteboardSession
 @feature_flag_whiteboards
 @login_required
 def get_whiteboard(whiteboard_id):
-    whiteboard = Whiteboard.find_by_id(whiteboard_id=whiteboard_id)
+    whiteboard = Whiteboard.find_by_id(whiteboard_id=whiteboard_id, include_deleted=True)
     if whiteboard and can_view_whiteboard(user=current_user, whiteboard=whiteboard):
         socket_id = request.args.get('socketId')
         if socket_id:
@@ -200,6 +200,8 @@ def update_whiteboard():
     whiteboard = Whiteboard.find_by_id(whiteboard_id) if whiteboard_id else None
     if not whiteboard:
         raise ResourceNotFoundError('Whiteboard not found.')
+    if whiteboard['deletedAt']:
+        raise ResourceNotFoundError('Whiteboard is read-only.')
     if not can_update_whiteboard(user=current_user, whiteboard=whiteboard):
         raise BadRequestError('To update a whiteboard you must own it or be a teacher in the course.')
 

--- a/squiggy/api/whiteboard_element_controller.py
+++ b/squiggy/api/whiteboard_element_controller.py
@@ -42,6 +42,8 @@ def create_whiteboard_elements():
     whiteboard = Whiteboard.find_by_id(whiteboard_id) if whiteboard_id else None
     if not whiteboard:
         raise ResourceNotFoundError('Whiteboard not found.')
+    if whiteboard['deletedAt']:
+        raise ResourceNotFoundError('Whiteboard is read-only.')
     if not len(whiteboard_elements):
         raise BadRequestError('One or more whiteboard-elements required')
     if not can_update_whiteboard(user=current_user, whiteboard=whiteboard):
@@ -69,6 +71,8 @@ def update_whiteboard_elements():
     whiteboard = Whiteboard.find_by_id(whiteboard_id=whiteboard_id)
     if not whiteboard:
         raise ResourceNotFoundError('Whiteboard not found.')
+    if whiteboard['deletedAt']:
+        raise ResourceNotFoundError('Whiteboard is read-only.')
     if not len(whiteboard_elements):
         raise BadRequestError('One or more elements required')
     if not can_update_whiteboard(user=current_user, whiteboard=whiteboard):

--- a/tests/test_api/test_whiteboard_controller.py
+++ b/tests/test_api/test_whiteboard_controller.py
@@ -47,11 +47,11 @@ def _api_get_whiteboard(whiteboard_id, client, expected_status_code=200):
 
 class TestGetWhiteboard:
 
-    def test_anonymous(self, client, mock_whiteboard):
+    def test_anonymous(self, client):
         """Denies anonymous user."""
         _api_get_whiteboard(whiteboard_id=1, client=client, expected_status_code=401)
 
-    def test_unauthorized(self, client, fake_auth, mock_whiteboard):
+    def test_unauthorized(self, client, fake_auth):
         """Denies unauthorized user."""
         fake_auth.login(unauthorized_user_id)
         _api_get_whiteboard(whiteboard_id=1, client=client, expected_status_code=401)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1775

Deleted whiteboards can be viewed, not modified.