### PR TITLE
COL-1791, in EB environments, start gunicorn/gevent server for socket.io

### DIFF
--- a/.platform/hooks/postdeploy/01_start_gunicorn_gevent_server.sh
+++ b/.platform/hooks/postdeploy/01_start_gunicorn_gevent_server.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+sudo gunicorn -k gevent -w 1 squiggy:app

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,7 @@ Flask-Login==0.5.0
 Flask-SocketIO==5.1.1
 Flask-SQLAlchemy==2.5.1
 Flask==2.0.3
+gevent==21.12.0
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.3

--- a/squiggy/lib/socket_io_util.py
+++ b/squiggy/lib/socket_io_util.py
@@ -36,7 +36,9 @@ def initialize_socket_io(app):
         logger=socket_logger,
     )
     if app.config['FEATURE_FLAG_WHITEBOARDS']:
-        socketio.run(app, debug=debug_socketio)
+        using_gunicorn_gevent_server = 'EB_ENVIRONMENT' in app.config
+        if not using_gunicorn_gevent_server:
+            socketio.run(app, debug=debug_socketio)
     return socketio
 
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1791

Per docs:
* https://flask-socketio.readthedocs.io/en/latest/deployment.html
* https://docs.gunicorn.org/en/stable/run.html