### PR TITLE
COL-1791, Ah-ha moment: socketio.run wraps flask.run

### DIFF
--- a/.platform/hooks/postdeploy/01_start_gunicorn_gevent_server.sh
+++ b/.platform/hooks/postdeploy/01_start_gunicorn_gevent_server.sh
@@ -1,4 +1,6 @@
 #!/bin/bash
 
-source "${PYTHONPATH}/activate"
-gunicorn -k gevent -w 1 squiggy:app
+# source "${PYTHONPATH}/activate"
+# gunicorn -k gevent -w 1 squiggy:app
+
+echo 'Delete this post-deploy script if proven unnecessary'

--- a/application.py
+++ b/application.py
@@ -52,7 +52,7 @@ if __name__.startswith('_mod_wsgi'):
         key, _, value = line.decode('utf-8').rstrip().partition('=')
         os.environ[key] = value
 
-application = create_app()
+application, socketio = create_app()
 
 
 @application.cli.command()
@@ -66,6 +66,13 @@ port = application.config['PORT']
 
 if __name__ == '__main__':
     application.logger.info('Starting development server on %s:%s', host, port)
-    application.run(host=host, port=port)
+    debug_socket = application.config['SOCKET_IO_DEBUG_MODE']
+    socketio.run(
+        app=application,
+        debug=debug_socket,
+        host=host,
+        log_output=debug_socket,
+        port=port,
+    )
 elif __name__.startswith('_mod_wsgi'):
     application.logger.info('Will start WSGI server on %s:%s', host, port)

--- a/consoler.py
+++ b/consoler.py
@@ -48,7 +48,7 @@ from pprintpp import pprint as pp # noqa
 
 """
 
-app = create_app()
+app, socketio = create_app()
 ac = app.app_context()
 ac.push()
 

--- a/squiggy/factory.py
+++ b/squiggy/factory.py
@@ -29,6 +29,7 @@ from flask import Flask
 from squiggy import db
 from squiggy.configs import load_configs
 from squiggy.lib.canvas_poller import launch_pollers
+from squiggy.lib.socket_io_util import create_mock_socket, initialize_socket_io
 from squiggy.logger import initialize_app_logger
 from squiggy.routes import register_routes
 
@@ -39,13 +40,14 @@ def create_app():
     load_configs(app)
     initialize_app_logger(app)
     db.init_app(app)
+    socketio = create_mock_socket() if app.config['TESTING'] else initialize_socket_io(app)
 
     with app.app_context():
-        register_routes(app)
+        register_routes(app, socketio)
 
         # See https://stackoverflow.com/questions/9449101/how-to-stop-flask-from-initialising-twice-in-debug-mode
         if not app.debug or os.environ.get('WERKZEUG_RUN_MAIN') == 'true':
             if app.config['CANVAS_POLLER']:
                 launch_pollers()
 
-    return app
+    return app, socketio

--- a/squiggy/lib/socket_io_util.py
+++ b/squiggy/lib/socket_io_util.py
@@ -35,10 +35,6 @@ def initialize_socket_io(app):
         engineio_logger=socket_logger,
         logger=socket_logger,
     )
-    if app.config['FEATURE_FLAG_WHITEBOARDS']:
-        using_gunicorn_gevent_server = 'EB_ENVIRONMENT' in app.config
-        if not using_gunicorn_gevent_server:
-            socketio.run(app, debug=debug_socketio)
     return socketio
 
 

--- a/squiggy/routes.py
+++ b/squiggy/routes.py
@@ -31,17 +31,15 @@ from flask_login import current_user, LoginManager
 from flask_socketio import emit
 from squiggy.api.api_util import start_login_session
 from squiggy.lib.login_session import LoginSession
-from squiggy.lib.socket_io_util import create_mock_socket, initialize_socket_io
 from squiggy.lib.util import is_admin, to_int
 from squiggy.models.user import User
 
 
-def register_routes(app):
+def register_routes(app, socketio):
     login_manager = LoginManager()
     login_manager.init_app(app)
     login_manager.user_loader(_user_loader)
     login_manager.anonymous_user = _user_loader
-    socketio = _initialize_socket_io(app)
 
     # Register API routes.
     import squiggy.api.activity_controller
@@ -132,10 +130,6 @@ def _handle_socketio_connect():
         emit('my response', {'message': '{0} has joined'.format(current_user.name)}, broadcast=True)
     else:
         return False  # not allowed here
-
-
-def _initialize_socket_io(app):
-    return create_mock_socket() if app.config['TESTING'] else initialize_socket_io(app)
 
 
 def _user_loader(user_id=None):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -74,7 +74,7 @@ class FakeAuth(object):
 @pytest.fixture(scope='session')
 def app(request):
     """Fixture application object, shared by all tests."""
-    _app = squiggy.factory.create_app()
+    _app, socketio = squiggy.factory.create_app()
 
     # Create app context before running tests.
     ctx = _app.app_context()


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1791

From [flask-socketio docs](https://flask-socketio.readthedocs.io/en/latest/getting_started.html): "...socketio.run() function encapsulates the start up of the web server and replaces the app.run() standard Flask development server start up."  This code change works locally, accepting both HTTP and socket connections. Let's see how it plays on dev. 