### PR TITLE
COL-1796, collapse add/update into upsert_whiteboard_element (create uuid client-side)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "lodash": "4.17.21",
         "moment-timezone": "0.5.34",
         "socket.io-client": "4.4.1",
+        "uuid": "^8.3.2",
         "vue": "2.6.14",
         "vue-fabric-wrapper": "0.3.71",
         "vue-infinite-loading": "2.4.5",
@@ -20840,7 +20841,6 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true,
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -39902,8 +39902,7 @@
     "uuid": {
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-      "dev": true
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
     },
     "v8-compile-cache": {
       "version": "2.2.0",

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "lodash": "4.17.21",
     "moment-timezone": "0.5.34",
     "socket.io-client": "4.4.1",
+    "uuid": "^8.3.2",
     "vue": "2.6.14",
     "vue-fabric-wrapper": "0.3.71",
     "vue-infinite-loading": "2.4.5",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,13 @@ boto3==1.20.24
 canvasapi==2.2.0
 cryptography==36.0.1
 decorator==5.1.1
+eventlet==0.33.0
 Flask-Login==0.5.0
 Flask-SocketIO==5.1.1
 Flask-SQLAlchemy==2.5.1
 Flask==2.0.3
 gevent==21.12.0
+gevent-websocket==0.10.1
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.3

--- a/squiggy/api/whiteboard_controller.py
+++ b/squiggy/api/whiteboard_controller.py
@@ -86,7 +86,14 @@ def export_as_asset(whiteboard_id):
                 users=[User.find_by_id(current_user.get_id())],
                 visible=True,
             )
-            AssetWhiteboardElement.create(asset_id=asset.id, whiteboard_elements=whiteboard_elements)
+            for whiteboard_element in whiteboard_elements:
+                element = whiteboard_element.element
+                AssetWhiteboardElement.create(
+                    asset_id=asset.id,
+                    element=element,
+                    element_asset_id=element.get('assetId'),
+                    uuid=element['uuid'],
+                )
             return tolerant_jsonify(Asset.find_by_id(asset_id=asset.id).to_api_json())
         else:
             raise BadRequestError('An empty whiteboard cannot be exported')

--- a/squiggy/models/asset_whiteboard_element.py
+++ b/squiggy/models/asset_whiteboard_element.py
@@ -51,15 +51,26 @@ class AssetWhiteboardElement(Base):
         self.uuid = uuid
 
     @classmethod
-    def create(cls, asset_id, whiteboard_elements):
-        for whiteboard_element in whiteboard_elements:
-            asset_whiteboard_element = cls(
+    def create(
+            cls,
+            asset_id,
+            element,
+            element_asset_id,
+            uuid,
+    ):
+        db.session.add(
+            cls(
                 asset_id=asset_id,
-                element=whiteboard_element.element,
-                element_asset_id=whiteboard_element.asset_id,
-                uuid=whiteboard_element.uuid,
-            )
-            db.session.add(asset_whiteboard_element)
+                element=element,
+                element_asset_id=element_asset_id,
+                uuid=uuid,
+            ),
+        )
+        std_commit()
+
+    @classmethod
+    def delete(cls, asset_id, uuid):
+        db.session.query(cls).filter_by(asset_id=asset_id, uuid=uuid).delete()
         std_commit()
 
     @classmethod

--- a/src/components/whiteboards/EditActiveFabricObject.vue
+++ b/src/components/whiteboards/EditActiveFabricObject.vue
@@ -39,9 +39,6 @@
         <span class="sr-only">Delete</span>
         <font-awesome-icon icon="trash" />
       </v-btn>
-      <div v-if="activeCanvasObject && $config.isVueAppDebugMode" class="pl-2 grey--text">
-        UUID: <span class="font-italic">{{ activeCanvasObject.toObject().uuid }}</span>
-      </div>
     </div>
   </div>
 </template>
@@ -62,20 +59,5 @@ export default {
   text-align: left;
   width: 180px;
   z-index: 1100;
-}
-.whiteboard-element-edit .btn-default {
-  padding: 5px 8px;
-}
-.whiteboard-element-edit .btn-default:not(:hover) {
-  background-color: #FFF;
-}
-.whiteboard-element-edit .btn-default i {
-  color: #666;
-  font-size: 17px;
-}
-.whiteboard-element-edit .btn-default i.fa-external-link {
-  left: 1px;
-  position: relative;
-  top: 2px;
 }
 </style>

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ from datetime import datetime
 import json
 import os
 from random import randint, randrange
+from uuid import uuid4
 
 from moto import mock_sts  # noqa
 import pytest  # noqa
@@ -236,6 +237,7 @@ def mock_whiteboard(app, db_session):
             {
                 'height': 600,
                 'type': 'canvas',
+                'uuid': str(uuid4()),
                 'width': 800,
             },
             {
@@ -243,6 +245,7 @@ def mock_whiteboard(app, db_session):
                 'fontSize': 14,
                 'text': '',
                 'type': 'text',
+                'uuid': str(uuid4()),
             },
         ],
         title=f'Mock Whiteboard of canvas_user_id {canvas_user_id}',

--- a/tests/test_api/test_whiteboard_controller.py
+++ b/tests/test_api/test_whiteboard_controller.py
@@ -25,6 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 import json
 from random import randint
+from uuid import uuid4
 
 from flask import current_app as app
 from squiggy import std_commit
@@ -216,7 +217,12 @@ class TestExportAsAsset:
     def test_authorized(self, authorized_user_id, client, fake_auth, mock_whiteboard):
         """Authorized user can export whiteboard as asset."""
         fake_auth.login(authorized_user_id)
-        WhiteboardElement.create(element={}, whiteboard_id=mock_whiteboard['id'])
+        WhiteboardElement.create(
+            element={
+                'fontSize': 14,
+                'uuid': str(uuid4()),
+            },
+            whiteboard_id=mock_whiteboard['id'])
         std_commit(allow_test_environment=True)
         api_json = self._api_export(client, whiteboard_id=mock_whiteboard['id'])
         assert 'id' in api_json


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1796

Generating uuid at client-side allows for simpler `upsert` logic. I'm also adding py-deps for gunicorn work in `squiggy-dev`.