### PR TITLE
COL-1757, EB predeploy hook to install nodejs, typescript compiler

### DIFF
--- a/.platform/hooks/predeploy/01_install_nodejs.sh
+++ b/.platform/hooks/predeploy/01_install_nodejs.sh
@@ -1,0 +1,3 @@
+curl -sL https://rpm.nodesource.com/setup_16.x | sudo bash -
+yum install -y nodejs
+npm install -g typescript


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1757

I don't think `sudo` is necessary but we'll find out.