### PR TITLE
COL-1850, inactive users are unauthorized in flask-login scheme

### DIFF
--- a/squiggy/lib/login_session.py
+++ b/squiggy/lib/login_session.py
@@ -32,7 +32,9 @@ class LoginSession:
     user = None
 
     def __init__(self, user_id):
-        self.user = User.find_by_id(user_id) if user_id else None
+        user = User.find_by_id(user_id) if user_id else None
+        is_authorized = user and (is_admin(user) or user.canvas_enrollment_state != 'inactive')
+        self.user = user if is_authorized else None
 
     def get_id(self):
         return self.user and self.user.id

--- a/squiggy/models/development_db.py
+++ b/squiggy/models/development_db.py
@@ -142,6 +142,13 @@ _test_users = [
         'canvas_email': 'anne-sophie@berkeley.edu',
     },
     {
+        'canvas_user_id': 8765433,
+        'canvas_course_role': 'Student',
+        'canvas_enrollment_state': 'inactive',
+        'canvas_full_name': 'Poly Styrene',
+        'canvas_email': 'x-ray-spex@berkeley.edu',
+    },
+    {
         'canvas_user_id': 4328765,
         'canvas_course_role': 'Student',
         'canvas_enrollment_state': 'active',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -310,4 +310,4 @@ def _get_mock_comments():
 
 
 def _get_student():
-    return User.query.filter_by(canvas_course_role='Student').first()
+    return User.query.filter_by(canvas_course_role='Student', canvas_enrollment_state='active').first()

--- a/tests/test_api/test_asset_controller.py
+++ b/tests/test_api/test_asset_controller.py
@@ -623,7 +623,7 @@ class TestLikeAsset:
 
     def test_likes_multiple_users_increment_remove_likes_decrement(self, client, fake_auth, mock_asset):
         course_users = Course.find_by_id(mock_asset.course_id).users
-        user_iterator = (user for user in course_users if user not in mock_asset.users)
+        user_iterator = (user for user in course_users if user not in mock_asset.users and user.canvas_enrollment_state == 'active')
         different_user_1 = next(user_iterator)
         different_user_2 = next(user_iterator)
         # Clean up any point values out of sync from earlier tests.

--- a/tests/test_api/test_auth_controller.py
+++ b/tests/test_api/test_auth_controller.py
@@ -88,6 +88,18 @@ class TestDevAuth:
                 expected_status_code=403,
             )
 
+    def test_canvas_enrollment_state(self, app, client):
+        """Fails if canvas_enrollment_state is not active."""
+        user = User.find_by_canvas_user_id(8765433)
+        assert user.canvas_enrollment_state == 'inactive'
+        with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):
+            self._api_dev_auth_login(
+                client,
+                password=app.config['DEVELOPER_AUTH_PASSWORD'],
+                user_id=user.id,
+                expected_status_code=403,
+            )
+
     def test_unauthorized_user(self, app, client):
         """Fails if the chosen user_id does not match an authorized user."""
         with override_config(app, 'DEVELOPER_AUTH_ENABLED', True):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1850

Users can also have canvas_enrollment_state of 'completed', 'invited', and 'rejected'. I decided to be conservative and only deny 'inactive' users. SuiteC piggy-backs on Canvas auth; many users are denied before they even reach our code.