### PR TITLE
COL-1860, 'whiteboard.users' must always be defined

### DIFF
--- a/squiggy/models/whiteboard.py
+++ b/squiggy/models/whiteboard.py
@@ -236,6 +236,7 @@ class Whiteboard(Base):
                 'thumbnailUrl': row['thumbnail_url'],
                 'title': row['title'],
                 'updatedAt': isoformat(row['updated_at']),
+                'users': [],
             }
             whiteboards_by_id[whiteboard_id] = whiteboard
             user_id = row['user_id']

--- a/src/components/whiteboards/DeleteWhiteboardDialog.vue
+++ b/src/components/whiteboards/DeleteWhiteboardDialog.vue
@@ -68,7 +68,8 @@ export default {
     }
   },
   created() {
-    this.showCollaborators = this.whiteboard.users.length > 1 || this.$currentUser.id !== this.whiteboard.users[0].id
+    const userCount = this.whiteboard.users.length
+    this.showCollaborators = !!userCount && (userCount > 1 || this.$currentUser.id !== this.whiteboard.users[0].id)
   },
   methods: {
     cancel() {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1860

A whiteboard can have zero collaborators if all of its users are 'inactive'.