### PR TITLE
COL-1861, /whiteboards page: delete_stale_sessions behind the scenes

### DIFF
--- a/squiggy/models/whiteboard.py
+++ b/squiggy/models/whiteboard.py
@@ -231,7 +231,12 @@ class Whiteboard(Base):
         """
         whiteboards_by_id = {}
         users_by_whiteboard_id = {}
-        for row in list(db.session.execute(sql, params)):
+        rows = list(db.session.execute(sql, params))
+
+        # Delete stale sessions
+        WhiteboardSession.delete_stale_sessions([row['id'] for row in rows])
+
+        for row in rows:
             whiteboard_id = int(row['id'])
             deleted_at = row['deleted_at']
             whiteboard = whiteboards_by_id.get(whiteboard_id) or {

--- a/squiggy/models/whiteboard_session.py
+++ b/squiggy/models/whiteboard_session.py
@@ -78,6 +78,21 @@ class WhiteboardSession(Base):
         std_commit()
 
     @classmethod
+    def delete_stale_sessions(cls, whiteboard_ids, older_than_minutes=5):
+        db.session.execute(
+            text("""
+                DELETE FROM whiteboard_sessions s
+                WHERE whiteboard_id = ANY(:whiteboard_ids)
+                  AND (updated_at < (now() - INTERVAL ':older_than_minutes minutes'))
+            """),
+            {
+                'older_than_minutes': older_than_minutes,
+                'whiteboard_ids': whiteboard_ids,
+            },
+        )
+        std_commit()
+
+    @classmethod
     def find(cls, whiteboard_id, user_id=None):
         if user_id:
             filter_by = cls.query.filter_by(user_id=user_id, whiteboard_id=whiteboard_id)

--- a/src/components/whiteboards/Whiteboards.vue
+++ b/src/components/whiteboards/Whiteboards.vue
@@ -85,6 +85,7 @@ export default {
   methods: {
     fetch() {
       return this.nextPage().then(() => {
+        this.isComplete = this.whiteboards.length === this.totalWhiteboardCount
         if (this.totalWhiteboardCount) {
           this.$announcer.polite(`${this.whiteboards.length} of ${this.totalWhiteboardCount} whiteboards loaded.`)
         } else {

--- a/src/store/whiteboarding/fabric-utils.ts
+++ b/src/store/whiteboarding/fabric-utils.ts
@@ -470,7 +470,6 @@ const $_addSocketListeners = (state: any) => {
         const callback = (e: any) => {
           // Add the element to the whiteboard canvas and move it to its appropriate index
           p.$canvas.add(e)
-          whiteboardElement.moveTo(e.get('index'))
           p.$canvas.requestRenderAll()
           // Recalculate the size of the whiteboard canvas
           setCanvasDimensions(state)


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1861

This SQL Delete is fairly efficient, operating on only the page results returned to client. I don't think /whiteboards performance will degrade noticeably.

Includes minor front-end fixes.