### PR TITLE
COL-1883, /whiteboard experiment continues: drop eventlet, bring back gevent

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,12 @@ boto3==1.20.24
 canvasapi==2.2.0
 cryptography==36.0.1
 decorator==5.1.1
-eventlet==0.33.1
 Flask-Login==0.6.0
 Flask-SocketIO==5.1.2
 Flask-SQLAlchemy==2.5.1
 Flask==2.0.3
+gevent==21.12.0
+gevent-websocket==0.10.1
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.3


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1883

@pfarestveit can merge this when ready.

Whiteboards do update dynamically on localhost. We must tweak the knobs on squiggy-dev.