### PR TITLE
COL-1883, Procfile for multi-worker gunicorn configuration

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,0 +1,1 @@
+web: gunicorn --bind 127.0.0.1:8000 --workers=6 --threads=5 --keep-alive=30 application

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,6 +7,7 @@ Flask-Login==0.6.0
 Flask-SocketIO==5.1.2
 Flask-SQLAlchemy==2.5.1
 Flask==2.0.3
+gevent-websocket==0.10.1
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.3


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1883

See https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/python-configuration-procfile.html

Bring back `gevent-websocket` (deleted in previous experimental PR) and add `gunicorn` command in Procfile.