### PR TITLE
COL-1890, cross-tool link not necessary in remix modal; url validation

### DIFF
--- a/squiggy/routes.py
+++ b/squiggy/routes.py
@@ -151,7 +151,8 @@ def _user_loader(user_id=None):
             if user_id:
                 candidate = LoginSession(user_id)
                 course = candidate.course
-                if course.canvas_api_domain == canvas_api_domain and str(course.canvas_course_id) == str(canvas_course_id):
+                is_matching_domain = course and course.canvas_api_domain == canvas_api_domain
+                if is_matching_domain and str(course.canvas_course_id) == str(canvas_course_id):
                     # User must be a member of the Canvas course site.
                     user_session = candidate
                     app.logger.info(f'User {user_id} loaded.')

--- a/src/components/assets/AddLinkAsset.vue
+++ b/src/components/assets/AddLinkAsset.vue
@@ -161,7 +161,7 @@ export default {
   methods: {
     ensureUrlPrefix() {
       if (this.url && this.url.indexOf('://') === -1) {
-        this.url = `http://${this.url}`
+        this.url = `https://${this.url}`
       }
     },
     submit() {

--- a/src/components/assets/RemixAsset.vue
+++ b/src/components/assets/RemixAsset.vue
@@ -86,7 +86,7 @@
                 <OxfordJoin v-slot="{item}" :items="whiteboard.users">
                   <div class="align-center d-flex pr-1">
                     <Avatar :user="item" />
-                    <UserLink :cross-tool-link="true" :user="item" />
+                    <UserLink :user="item" />
                   </div>
                 </OxfordJoin>
                 <div class="pt-1">

--- a/src/components/whiteboards/toolbar/assets/AddLinkAsset.vue
+++ b/src/components/whiteboards/toolbar/assets/AddLinkAsset.vue
@@ -205,7 +205,7 @@ export default {
   methods: {
     ensureUrlPrefix() {
       if (this.asset.url && this.asset.url.indexOf('://') === -1) {
-        this.asset.url = `http://${this.asset.url}`
+        this.asset.url = `https://${this.asset.url}`
       }
     },
     onClickCancel() {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1890

If user does not prepend protocol on url input then we add 'https' prefix.