### PR TITLE
COL-1844, put eventlet back at v0.30.2 (revert Friday's bump)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.20.24
 canvasapi==2.2.0
 cryptography==37.0.2
 decorator==5.1.1
-eventlet==0.33.1
+eventlet==0.30.2
 Flask-Login==0.6.1
 Flask-SocketIO==5.2.0
 Flask-SQLAlchemy==2.5.1


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1844

If it ain't broke then don't fix it.