### PR TITLE
COL-1923, async processing of whiteboard_element transactions

### DIFF
--- a/src/store/whiteboarding/fabric-utils.ts
+++ b/src/store/whiteboarding/fabric-utils.ts
@@ -601,9 +601,7 @@ const $_addSocketListeners = (state: any) => {
     })
   })
 
-  // One or multiple whiteboard canvas elements were deleted by a different user
-  p.$socket.on('delete_whiteboard_element', (data: any) => {
-    const uuid = data.uuid
+  p.$socket.on('delete_whiteboard_element', (uuid: string) => {
     const element = $_getCanvasElement(uuid)
     if (element) {
       // Deactivate the current group if any of the deleted elements are in the current group
@@ -653,7 +651,10 @@ const $_broadcastDelete = (element: any, state: any) => {
   return new Promise<void>(resolve => {
     const args = {
       userId: p.$currentUser.id,
-      whiteboardElement: {element},
+      whiteboardElement: {
+        element,
+        uuid: element.uuid
+      },
       whiteboardId: state.whiteboard.id
     }
     p.$socket.emit('delete_whiteboard_element', args, (uuid: string) => {

--- a/tests/test_api/test_whiteboard_socket_handler.py
+++ b/tests/test_api/test_whiteboard_socket_handler.py
@@ -46,8 +46,9 @@ class TestCreateWhiteboardElement:
         """Denies anonymous user."""
         with pytest.raises(BadRequestError):
             upsert_whiteboard_element(
-                current_user=LoginSession(user_id=None),
+                course_id=None,
                 socket_id=_get_mock_socket_id(),
+                user_id=None,
                 whiteboard_element=_mock_whiteboard_element(),
                 whiteboard_id=mock_whiteboard['id'],
             )
@@ -55,9 +56,11 @@ class TestCreateWhiteboardElement:
     def test_unauthorized(self, mock_whiteboard):
         """Denies unauthorized user."""
         with pytest.raises(ResourceNotFoundError):
+            current_user = _get_non_collaborator(mock_whiteboard)
             upsert_whiteboard_element(
-                current_user=_get_non_collaborator(mock_whiteboard),
+                course_id=current_user.course.id,
                 socket_id=_get_mock_socket_id(),
+                user_id=current_user.user_id,
                 whiteboard_element=_mock_whiteboard_element(),
                 whiteboard_id=mock_whiteboard['id'],
             )
@@ -71,8 +74,9 @@ class TestCreateWhiteboardElement:
         with mock_s3_bucket(app):
             current_user = _get_authorized_user(mock_whiteboard)
             api_json = upsert_whiteboard_element(
-                current_user=current_user,
+                course_id=current_user.course.id,
                 socket_id=_get_mock_socket_id(),
+                user_id=current_user.user_id,
                 whiteboard_element=whiteboard_element,
                 whiteboard_id=mock_whiteboard['id'],
             )
@@ -101,8 +105,9 @@ class TestUpdateWhiteboardElements:
             current_user = LoginSession(user_id=None)
             for whiteboard_element in mock_whiteboard['whiteboardElements']:
                 upsert_whiteboard_element(
-                    current_user=current_user,
+                    course_id=current_user.course.id,
                     socket_id=_get_mock_socket_id(),
+                    user_id=current_user.user_id,
                     whiteboard_element=whiteboard_element,
                     whiteboard_id=mock_whiteboard['id'],
                 )
@@ -113,8 +118,9 @@ class TestUpdateWhiteboardElements:
             current_user = LoginSession(user_id=None)
             for whiteboard_element in mock_whiteboard['whiteboardElements']:
                 upsert_whiteboard_element(
-                    current_user=current_user,
+                    course_id=current_user.course.id,
                     socket_id=_get_mock_socket_id(),
+                    user_id=current_user.user_id,
                     whiteboard_element=whiteboard_element,
                     whiteboard_id=mock_whiteboard['id'],
                 )
@@ -133,8 +139,9 @@ class TestUpdateWhiteboardElements:
             for whiteboard_element in mock_whiteboard['whiteboardElements']:
                 results.append(
                     upsert_whiteboard_element(
-                        current_user=current_user,
+                        course_id=current_user.course.id,
                         socket_id=_get_mock_socket_id(),
+                        user_id=current_user.user_id,
                         whiteboard_element=whiteboard_element,
                         whiteboard_id=mock_whiteboard['id'],
                     ),


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1923

For now, only 'delete' transactions are put in async queue.  The WhiteboardHousekeeping job is always processing these transactions while the other tasks (eg, generate previews) still happen every 15 seconds.

The plan is to fold in 'upsert' transactions, too.  We can add throttling in WhiteboardHousekeeping, as needed.