### PR TITLE
COL-1914, PNG exports include all elements, properly stacked and sized

### DIFF
--- a/scripts/developer_debug_whiteboard_as_png.sh
+++ b/scripts/developer_debug_whiteboard_as_png.sh
@@ -52,6 +52,6 @@ node \
   -w "${BASE_DIR}/tmp/elements.json" \
   -v true
 
-echo -e "\nPNG file: ${PNG_FILE}\nDone.\n"
+echo -e "\nPNG file: ${PNG_FILE}\n\nBye!\n"
 
 exit 0


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1914

And this `ts` script is a bit more readable. 