### PR TITLE
COL-1887, socket listeners not working in squiggy-dev? use 'namespace' consistently?

### DIFF
--- a/squiggy/sockets.py
+++ b/squiggy/sockets.py
@@ -34,6 +34,9 @@ from squiggy.models.whiteboard import Whiteboard
 from squiggy.models.whiteboard_session import WhiteboardSession
 
 
+SOCKET_IO_NAMESPACE = '/'
+
+
 def register_sockets(socketio):
     logger = initialize_background_logger(
         name='whiteboard_sockets',
@@ -59,6 +62,7 @@ def register_sockets(socketio):
                 current_user.user_id,
                 broadcast=True,
                 include_self=False,
+                namespace=SOCKET_IO_NAMESPACE,
                 skip_sid=socket_id,
                 to=room,
             )
@@ -78,6 +82,7 @@ def register_sockets(socketio):
                 'leave',
                 current_user.user_id,
                 include_self=False,
+                namespace=SOCKET_IO_NAMESPACE,
                 skip_sid=socket_id,
                 to=room,
             )
@@ -101,6 +106,7 @@ def register_sockets(socketio):
                 'whiteboardId': whiteboard_id,
             },
             include_self=False,
+            namespace=SOCKET_IO_NAMESPACE,
             skip_sid=socket_id,
             to=get_socket_io_room(whiteboard_id),
         )
@@ -122,6 +128,7 @@ def register_sockets(socketio):
             },
             broadcast=True,
             include_self=True,
+            namespace=SOCKET_IO_NAMESPACE,
         )
         return {'status': 200}
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1887

Yes, ugh.  This regression was likely caused by having socket.emits (server-side) moved out of `sockets.py` and into `whiteboard_element_controller`.  My first guess is that the problem is related to `namespace` or `socket_id`.  This PR will tell us more.