### PR TITLE
COL-1932, page reload when (un)delete; no fancy socket/canvas re-init

### DIFF
--- a/src/components/whiteboards/toolbar/RestoreWhiteboard.vue
+++ b/src/components/whiteboards/toolbar/RestoreWhiteboard.vue
@@ -76,7 +76,7 @@ export default {
   mixins: [Whiteboarding],
   components: {OxfordJoin, PageTitle},
   props: {
-    afterRestore: {
+    restore: {
       required: true,
       type: Function
     },
@@ -91,16 +91,6 @@ export default {
   }),
   created() {
     this.canRestore = this.whiteboard.deletedAt && (this.$currentUser.isAdmin || this.$currentUser.isTeaching)
-  },
-  methods: {
-    restore() {
-      this.isRestoring = true
-      this.undeleteWhiteboard().then(() => {
-        this.$announcer.polite('Whiteboard restored.')
-        this.isRestoring = false
-        this.afterRestore()
-      })
-    }
   }
 }
 </script>

--- a/src/components/whiteboards/toolbar/SettingsTool.vue
+++ b/src/components/whiteboards/toolbar/SettingsTool.vue
@@ -24,7 +24,7 @@
       <v-card-text class="scrollable-card">
         <RestoreWhiteboard
           v-if="whiteboard.deletedAt"
-          :after-restore="close"
+          :restore="restore"
           :on-cancel="close"
         />
         <EditWhiteboard
@@ -84,6 +84,14 @@ export default {
     onClickDelete() {
       this.close()
       this.openDeleteDialog()
+    },
+    restore() {
+      this.menu = false
+      this.setDisableAll(true)
+      this.$loading()
+      this.undeleteWhiteboard().then(() => {
+        this.$announcer.polite('Whiteboard restored')
+      })
     }
   }
 }

--- a/src/components/whiteboards/toolbar/Toolbar.vue
+++ b/src/components/whiteboards/toolbar/Toolbar.vue
@@ -108,6 +108,8 @@ export default {
     },
     deleteConfirmed() {
       this.isDeleting = true
+      this.setDisableAll(true)
+      this.$loading()
       this.deleteWhiteboard().then(() => {
         this.isDeleteDialogOpen = false
         this.isDeleting = false

--- a/src/store/whiteboarding.ts
+++ b/src/store/whiteboarding.ts
@@ -10,7 +10,6 @@ import {
   deleteActiveElements,
   initialize,
   moveLayer,
-  reload,
   setCanvasDimensions,
   updatePreviewImage
 } from '@/store/whiteboarding/fabric-utils'
@@ -118,6 +117,10 @@ const mutations = {
     })
     state.whiteboard.users = users
     // Whiteboard might have been deleted.
+    const hasDeleteStatusChanged = (!state.whiteboard.deletedAt && deletedAt) || (state.whiteboard.deletedAt && !deletedAt)
+    if (hasDeleteStatusChanged) {
+      state.whiteboard.deletedAt = deletedAt
+    }
     state.whiteboard.deletedAt = deletedAt
     // Close browser tab if current user is no longer authorized.
     if (!p.$currentUser.isAdmin && !p.$currentUser.isTeaching) {
@@ -132,7 +135,10 @@ const mutations = {
         }
       }
     }
-    reload(state).then(resolve)
+    if (hasDeleteStatusChanged) {
+      p.$loading()
+      location.reload()
+    }
   },
   onWindowResize: (state: any) => {
     state.windowHeight = window.innerHeight

--- a/src/store/whiteboarding/fabric-utils.ts
+++ b/src/store/whiteboarding/fabric-utils.ts
@@ -156,42 +156,6 @@ export function moveLayer(direction: string, state: any) {
   $_invokeWithSocketConnectRetry('update whiteboard elements order', apiCall, state)
 }
 
-export function reload(state: any) {
-  store.commit('whiteboarding/setIsInitialized', false)
-  return new Promise<void>(resolve => {
-    $_log(`Reload ${state.whiteboard.deletedAt ? 'deleted ' : ''}whiteboard`)
-    const isDeleted = state.whiteboard.deletedAt
-    store.dispatch('whiteboarding/setDisableAll', isDeleted).then(_.noop)
-    if (isDeleted) {
-      $_initSocket(state)
-      $_initCanvas(state)
-      $_renderWhiteboard(state, true).then(() => {
-        $_enableCanvasElements(false)
-        store.commit('whiteboarding/setIsInitialized', true)
-        resolve()
-      })
-    } else {
-      if (!p.$socket) {
-        $_initSocket(state)
-        $_addSocketListeners(state)
-      }
-      if (p.$canvas) {
-        resolve()
-      } else {
-        // Order matters: (1) set up Fabric prototypes, (2) initialize the canvas.
-        $_initFabricPrototypes(state)
-        $_initCanvas(state)
-        $_addViewportListeners(state)
-        $_renderWhiteboard(state, true).then(() => {
-          $_enableCanvasElements(true)
-          store.commit('whiteboarding/setIsInitialized', true)
-          resolve()
-        })
-      }
-    }
-  })
-}
-
 export function setCanvasDimensions(state: any) {
   $_log('Set canvas dimensions')
   // Set the width and height of the whiteboard canvas. The width of the visible canvas will be the same for all users,

--- a/tests/test_api/test_whiteboard_controller.py
+++ b/tests/test_api/test_whiteboard_controller.py
@@ -432,36 +432,36 @@ class TestRemixWhiteboard:
 #         self._api_refresh_whiteboard_preview(mock_whiteboard['id'], client)
 #         asset_feed = _api_get_whiteboard(mock_whiteboard['id'], client)
 #         assert asset_feed['previewStatus'] == 'pending'
-#
-#
-# class TestDeleteWhiteboard:
-#
-#     @staticmethod
-#     def _api_delete_whiteboard(whiteboard_id, client, expected_status_code=200):
-#         response = client.delete(f'/api/whiteboard/{whiteboard_id}/delete')
-#         assert response.status_code == expected_status_code
-#
-#     def test_anonymous(self, client):
-#         """Denies anonymous user."""
-#         self._api_delete_whiteboard(whiteboard_id=1, client=client, expected_status_code=401)
-#
-#     def test_unauthorized(self, client, fake_auth):
-#         """Denies unauthorized user."""
-#         fake_auth.login(unauthorized_user_id)
-#         self._api_delete_whiteboard(whiteboard_id=1, client=client, expected_status_code=401)
-#
-#     def test_delete_whiteboard_by_teacher(self, client, fake_auth, mock_whiteboard):
-#         """Authorized user can delete whiteboard."""
-#         course = Course.find_by_id(mock_whiteboard['courseId'])
-#         instructors = list(filter(lambda u: is_teaching(u), course.users))
-#         fake_auth.login(instructors[0].id)
-#         self._verify_delete_whiteboard(mock_whiteboard['id'], client)
-#
-#     def _verify_delete_whiteboard(self, whiteboard_id, client):
-#         self._api_delete_whiteboard(whiteboard_id=whiteboard_id, client=client)
-#         std_commit(allow_test_environment=True)
-#         response = client.get(f'/api/whiteboard/{whiteboard_id}')
-#         assert response.status_code == 404
+
+
+class TestDeleteWhiteboard:
+
+    @staticmethod
+    def _api_delete_whiteboard(whiteboard_id, client, expected_status_code=200):
+        response = client.delete(f'/api/whiteboard/{whiteboard_id}/delete?socketId=${_get_mock_socket_id()}')
+        assert response.status_code == expected_status_code
+
+    def test_anonymous(self, client):
+        """Denies anonymous user."""
+        self._api_delete_whiteboard(whiteboard_id=1, client=client, expected_status_code=401)
+
+    def test_unauthorized(self, client, fake_auth):
+        """Denies unauthorized user."""
+        fake_auth.login(unauthorized_user_id)
+        self._api_delete_whiteboard(whiteboard_id=1, client=client, expected_status_code=401)
+
+    def test_delete_whiteboard_by_teacher(self, client, fake_auth, mock_whiteboard):
+        """Authorized user can delete whiteboard."""
+        course = Course.find_by_id(mock_whiteboard['courseId'])
+        instructors = list(filter(lambda u: is_teaching(u), course.users))
+        fake_auth.login(instructors[0].id)
+        whiteboard_id = mock_whiteboard['id']
+        self._api_delete_whiteboard(whiteboard_id=whiteboard_id, client=client)
+        std_commit(allow_test_environment=True)
+        response = client.get(f'/api/whiteboard/{whiteboard_id}')
+        assert response.status_code == 200
+        assert response.json['deletedAt']
+
 
 def _create_student_whiteboard():
     course = Course.find_by_canvas_course_id(


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1932

Less code / complexity.  Once user has (un)deleted we lock all controls, spin the spinner, and refresh the page when API call is done. 