### PR TITLE
COL-1966, paste-element does not require active objects

### DIFF
--- a/src/store/whiteboarding.ts
+++ b/src/store/whiteboarding.ts
@@ -71,7 +71,6 @@ const getters = {
 
 const mutations = {
   addAssets: (state: any, assets: any[]) => addAssets(assets, state),
-  clearClipboard: (state: any) => state.clipboard = [],
   copy: (state: any, object: any) => state.clipboard.push(object),
   deleteActiveElements: (state: any) => deleteActiveElements(state),
   initialize: (state: any, resolve: any) => initialize(state).then(resolve),

--- a/src/store/whiteboarding/fabric-utils.ts
+++ b/src/store/whiteboarding/fabric-utils.ts
@@ -920,12 +920,10 @@ const $_log = (statement: string, force?: boolean) => {
 const $_paste = (state: any): void => {
   $_log('Paste')
   const copies = state.clipboard
-  store.commit('whiteboarding/clearClipboard')
-
   if (copies.length) {
     // Clear the current selection
     const object = p.$canvas.getActiveObject()
-    if (object.type === constants.FABRIC_MULTIPLE_SELECT_TYPE) {
+    if (object && object.type === constants.FABRIC_MULTIPLE_SELECT_TYPE) {
       p.$canvas.remove(object)
     }
     const whiteboardElements: any[] = []


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1966

...and I've removed the line to clear-clipboard-on-paste so user can paste as many duplicates as desired.