### PR TITLE
COL-1970, /whiteboard: set mode to 'move' after exit-editing iText

### DIFF
--- a/src/store/whiteboarding/fabric-utils.ts
+++ b/src/store/whiteboarding/fabric-utils.ts
@@ -121,7 +121,7 @@ export function moveLayer(direction: string, state: any) {
     return direction === 'back' ? elementB.index - elementA.index : elementA.index - elementB.index
   })
   const selection = p.$canvas.getActiveObject()
-  if (selection.type === constants.FABRIC_MULTIPLE_SELECT_TYPE) {
+  if (selection && selection.type === constants.FABRIC_MULTIPLE_SELECT_TYPE) {
     p.$canvas.remove(selection)
   }
   _.each(elements, (e: any) => {
@@ -859,6 +859,7 @@ const $_initFabricPrototypes = (state: any) => {
       // If the text element is empty, it can be removed from the whiteboard canvas
       const text = element.text.trim()
       if (text) {
+        setMode('move')
         // The text element existed before. Notify the server that the element was updated
         const days_until_retirement = $_getDaysUntilRetirement()
         if (days_until_retirement === 0) {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1970

You cannot edit an existing text element if mode remains 'text'.  This is a problem if user creates text and then wants to immediately fix.