### PR TITLE
COL-1962 When emitting asset previews, omit no one

### DIFF
--- a/squiggy/api/previews_controller.py
+++ b/squiggy/api/previews_controller.py
@@ -117,7 +117,6 @@ def _update_asset_preview(metadata, params):
             emit(
                 'upsert_whiteboard_elements',
                 [whiteboard_element],
-                include_self=False,
                 namespace=SOCKET_IO_NAMESPACE,
                 to=get_socket_io_room(whiteboard_element['whiteboardId']),
             )


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1962

Follow-up to #638.