### PR TITLE
COL-1994, use promises.all (instead of _.each index) for updatePreviewImage loop

### DIFF
--- a/src/store/whiteboarding.ts
+++ b/src/store/whiteboarding.ts
@@ -152,21 +152,17 @@ const mutations = {
     state.whiteboard.users = whiteboard.users
     const count = whiteboard.whiteboardElements.length
     if (count) {
-      let modified = false
-      _.each(whiteboard.whiteboardElements, (whiteboardElement: any, index: number) => {
-        const uuid = whiteboardElement.uuid
-        const after = (index) => {
-          if (index === count - 1) {
-            if (modified) {
-              setCanvasDimensions(state)
-            }
-            resolve()
-          }
+      const promises: any[] = []
+      _.each(whiteboard.whiteboardElements, (whiteboardElement: any) => {
+        promises.push(new Promise<boolean>((resolve: any) => {
+          updatePreviewImage(whiteboardElement.element, state, whiteboardElement.uuid).then(resolve)
+        }))
+      })
+      Promise.all(promises).then((values: boolean[]) => {
+        if (values.includes(true)) {
+          setCanvasDimensions(state)
         }
-        updatePreviewImage(whiteboardElement.element, state, uuid).then((wasUpdated: boolean) => {
-          modified = wasUpdated
-          after(index)
-        })
+        resolve()
       })
     } else {
       resolve()


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1994

A best practice; less risk of missing image-preview update. 