### PR TITLE
COL-2084, os.remove temp PNG file, after whiteboard generate preview/download

### DIFF
--- a/squiggy/lib/file_remover.py
+++ b/squiggy/lib/file_remover.py
@@ -1,0 +1,47 @@
+"""
+Copyright ©2022. The Regents of the University of California (Regents). All Rights Reserved.
+
+Permission to use, copy, modify, and distribute this software and its documentation
+for educational, research, and not-for-profit purposes, without fee and without a
+signed licensing agreement, is hereby granted, provided that the above copyright
+notice, this paragraph and the following two paragraphs appear in all copies,
+modifications, and distributions.
+
+Contact The Office of Technology Licensing, UC Berkeley, 2150 Shattuck Avenue,
+Suite 510, Berkeley, CA 94720-1620, (510) 643-7201, otl@berkeley.edu,
+http://ipira.berkeley.edu/industry-info for commercial licensing opportunities.
+
+IN NO EVENT SHALL REGENTS BE LIABLE TO ANY PARTY FOR DIRECT, INDIRECT, SPECIAL,
+INCIDENTAL, OR CONSEQUENTIAL DAMAGES, INCLUDING LOST PROFITS, ARISING OUT OF
+THE USE OF THIS SOFTWARE AND ITS DOCUMENTATION, EVEN IF REGENTS HAS BEEN ADVISED
+OF THE POSSIBILITY OF SUCH DAMAGE.
+
+REGENTS SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE. THE
+SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
+"AS IS". REGENTS HAS NO OBLIGATION TO PROVIDE MAINTENANCE, SUPPORT, UPDATES,
+ENHANCEMENTS, OR MODIFICATIONS.
+"""
+
+import shutil
+import weakref
+
+from squiggy.logger import logger
+
+
+class FileRemover(object):
+
+    def __init__(self):
+        self.weak_references = dict()
+
+    def clean_up_when_done(self, response, file_path):
+        wr = weakref.ref(response, self._do_cleanup)
+        self.weak_references[wr] = file_path
+
+    def _do_cleanup(self, wr):
+        file_path = self.weak_references[wr]
+        logger.info(f'Delete transient file {file_path}')
+        shutil.rmtree(file_path, ignore_errors=True)
+
+
+file_remover = FileRemover()

--- a/squiggy/lib/previews.py
+++ b/squiggy/lib/previews.py
@@ -26,6 +26,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 import base64
 import hashlib
 import hmac
+import os
 import re
 
 from flask import current_app as app
@@ -74,7 +75,8 @@ def generate_whiteboard_preview(whiteboard):
     if app.config['PREVIEWS_ENABLED']:
         png_file = to_png_file(whiteboard)
         now = local_now().strftime('%Y-%m-%d_%H-%M-%S')
-        with open(png_file.name, mode='rb') as f:
+        file_name = png_file.name
+        with open(file_name, mode='rb') as f:
             filename = re.sub(r'[^a-zA-Z0-9]', '_', whiteboard['title'])
             s3_attrs = upload_to_s3(
                 byte_stream=f.read(),
@@ -88,6 +90,7 @@ def generate_whiteboard_preview(whiteboard):
             ):
                 # TODO: If preview-image status is needed then the 'whiteboards' table needs 'preview_status' column.
                 pass
+        os.remove(file_name)
 
 
 def get_s3_key_prefix(course_id, object_type):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2084

Inspired by 
* https://stackoverflow.com/questions/13344538/how-to-clean-up-temporary-file-used-with-send-file
* https://docs.python.org/3/library/weakref.html