### PR TITLE
COL-2099 Show download option for exported whiteboards

### DIFF
--- a/squiggy/lib/whiteboard_housekeeping.py
+++ b/squiggy/lib/whiteboard_housekeeping.py
@@ -27,7 +27,6 @@ from time import sleep
 
 from sqlalchemy import text
 from squiggy import db
-from squiggy.lib.aws import get_s3_signed_url
 from squiggy.lib.background_job import BackgroundJob
 from squiggy.lib.login_session import LoginSession
 from squiggy.lib.previews import generate_whiteboard_preview
@@ -99,7 +98,7 @@ class WhiteboardHousekeeping(BackgroundJob):
                 if image_url:
                     Whiteboard.update_preview(
                         whiteboard_id=whiteboard['id'],
-                        image_url=get_s3_signed_url(image_url),
+                        image_url=image_url,
                     )
             else:
                 self.logger.error(f'Whiteboard {whiteboard_id} gets no preview because instructor not found.')

--- a/src/components/assets/AssetPageHeader.vue
+++ b/src/components/assets/AssetPageHeader.vue
@@ -126,7 +126,7 @@ export default {
     }
   },
   created() {
-    if (this.asset.assetType === 'file') {
+    if (this.asset.assetType === 'file' || this.asset.assetType === 'whiteboard') {
       this.downloadUrl = `${this.$config.apiBaseUrl}/api/asset/${this.asset.id}/download`
     }
     const isTeacherOrAdmin = this.$currentUser.isAdmin || this.$currentUser.isTeaching


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2099

Also revert the URL signing in #802 since we don't actually want presigned URLs in the db.