### PR TITLE
COL-2016, upgrade to Flask/Werkzeug 2.2.2; requires flask-login changes

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,29 +3,29 @@ canvasapi==3.0.0
 cryptography==38.0.1
 decorator==5.1.1
 eventlet==0.30.2
-Flask-Login==0.6.1
+Flask-Login==0.6.2
 Flask-SocketIO==5.3.1
-Flask-SQLAlchemy==2.5.1
-Flask==2.1.2
+Flask-SQLAlchemy==3.0.2
+Flask==2.2.2
 gunicorn==20.1.0
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.4
 python-dateutil==2.8.2
 python-magic==0.4.27
-pytz==2022.4
+pytz==2022.5
 requests==2.28.1
 simplejson==3.17.6
 smart-open==4.2.0
-SQLAlchemy==1.4.41
+SQLAlchemy==1.4.42
 sqlvalidator==0.0.19
-Werkzeug==2.1.2
+Werkzeug==2.2.2
 https://github.com/python-cas/python-cas/archive/master.zip
 
 # For testing
 
 moto==3.1.16
-pytest==7.1.3
+pytest==7.2.0
 pytest-flask==1.2.0
 responses==0.22.0
-tox==3.26.0
+tox==3.27.0

--- a/squiggy/api/auth_controller.py
+++ b/squiggy/api/auth_controller.py
@@ -60,9 +60,9 @@ def dev_auth_login():
 def logout():
     response = tolerant_jsonify(current_user.to_api_json())
     # Delete our custom cookies
-    canvas_api_domain = current_user.course.canvas_api_domain
+    canvas_api_domain = current_user.canvas_api_domain
     keys = [
-        f'{canvas_api_domain}|{current_user.course.canvas_course_id}',
+        f'{canvas_api_domain}|{current_user.canvas_course_id}',
         f'{canvas_api_domain}_supports_custom_messaging',
     ]
     for key in keys:

--- a/squiggy/api/category_controller.py
+++ b/squiggy/api/category_controller.py
@@ -37,7 +37,7 @@ from squiggy.models.category import Category
 def get_categories():
     include_hidden = to_bool_or_none(request.args.get('includeHidden'))
     categories = Category.get_categories_by_course_id(
-        course_id=current_user.course.id,
+        course_id=current_user.course_id,
         include_hidden=include_hidden,
     )
     return tolerant_jsonify(Category.to_decorated_json(categories))
@@ -52,7 +52,7 @@ def create_category():
         raise BadRequestError('Category creation requires title.')
     category = Category.create(
         canvas_assignment_name=title,
-        course_id=current_user.course.id,
+        course_id=current_user.course_id,
         title=title,
     )
     return tolerant_jsonify(category.to_api_json())

--- a/squiggy/api/comment_controller.py
+++ b/squiggy/api/comment_controller.py
@@ -25,7 +25,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 
 from flask import current_app as app, request
 from flask_login import current_user, login_required
-from squiggy.api.api_util import can_delete_comment, can_update_comment, can_view_asset
+from squiggy.api.api_util import can_current_user_delete_comment, can_current_user_update_comment, can_current_user_view_asset
 from squiggy.lib.errors import BadRequestError, ResourceNotFoundError
 from squiggy.lib.http import tolerant_jsonify
 from squiggy.models.asset import Asset
@@ -39,7 +39,7 @@ def create_comment():
     params = request.get_json()
     asset_id = params.get('assetId')
     asset = Asset.find_by_id(asset_id=asset_id)
-    if asset and can_view_asset(asset=asset, user=current_user):
+    if asset and can_current_user_view_asset(asset=asset):
         body = params.get('body', '').strip()
         if not body:
             raise BadRequestError('Comment body is required.')
@@ -59,7 +59,7 @@ def create_comment():
 @login_required
 def get_comments(asset_id):
     asset = Asset.find_by_id(asset_id=asset_id)
-    if asset and can_view_asset(asset=asset, user=current_user):
+    if asset and can_current_user_view_asset(asset=asset):
         return tolerant_jsonify(_decorate_comments(Comment.get_comments(asset.id)))
     else:
         raise ResourceNotFoundError('Asset is either unavailable or non-existent.')
@@ -69,7 +69,7 @@ def get_comments(asset_id):
 @login_required
 def delete_comment(comment_id):
     comment = Comment.find_by_id(comment_id=comment_id)
-    if comment and can_delete_comment(comment=comment, user=current_user):
+    if comment and can_current_user_delete_comment(comment=comment):
         Comment.delete(comment_id=comment_id)
         return tolerant_jsonify({'message': f'Comment {comment_id} deleted'}), 200
     else:
@@ -81,7 +81,7 @@ def delete_comment(comment_id):
 def update_comment(comment_id):
     params = request.get_json()
     comment = Comment.find_by_id(comment_id=comment_id)
-    if comment and can_update_comment(comment=comment, user=current_user):
+    if comment and can_current_user_update_comment(comment=comment):
         body = params.get('body', '').strip()
         if not body:
             raise BadRequestError('Comment body is required.')

--- a/squiggy/api/course_controller.py
+++ b/squiggy/api/course_controller.py
@@ -33,7 +33,8 @@ from squiggy.models.course import Course
 @app.route('/api/course/activate', methods=['POST'])
 @teacher_required
 def activate():
-    current_user.course.activate()
+    course = Course.find_by_id(current_user.course_id)
+    course.activate()
     return tolerant_jsonify({'status': 'success'})
 
 
@@ -48,5 +49,5 @@ def get_course(course_id):
 def update_protect_assets_per_section_checkbox():
     params = request.get_json()
     protect_assets_per_section = params.get('protectSectionCheckbox')
-    Course.update_protect_assets_per_section(current_user.course.id, protect_assets_per_section)
+    Course.update_protect_assets_per_section(current_user.course_id, protect_assets_per_section)
     return tolerant_jsonify({'status': 'success'})

--- a/squiggy/lib/login_session.py
+++ b/squiggy/lib/login_session.py
@@ -23,70 +23,131 @@ SOFTWARE AND ACCOMPANYING DOCUMENTATION, IF ANY, PROVIDED HEREUNDER IS PROVIDED
 ENHANCEMENTS, OR MODIFICATIONS.
 """
 
+from sqlalchemy.sql import text
+from squiggy import db
 from squiggy.lib.util import is_admin, is_observer, is_student, is_teaching
 from squiggy.models.user import User
 
 
 class LoginSession:
 
-    user = None
+    api_json = None
+    user_id = None
 
     def __init__(self, user_id):
-        user = User.find_by_id(user_id) if user_id else None
-        is_authorized = user and (is_admin(user) or user.canvas_enrollment_state != 'inactive')
-        self.user = user if is_authorized else None
+        self.user_id = user_id
+        self.refresh()
 
     def get_id(self):
-        return self.user and self.user.id
+        return self._get('id')
+
+    @property
+    def asset_ids(self):
+        sql = 'SELECT asset_id FROM asset_users WHERE user_id = :id'
+        rows = db.session.execute(text(sql), {'id': self.id}).all()
+        return [row['asset_id'] for row in rows]
 
     @property
     def canvas_course_role(self):
-        return self.user and self.user.canvas_course_role
+        return self._get('canvasCourseRole')
 
     @property
-    def course(self):
-        return self.user and self.user.course
+    def course_id(self):
+        return self._get('course.id')
+
+    @property
+    def canvas_api_domain(self):
+        return self._get('course.canvasApiDomain')
+
+    @property
+    def canvas_course_id(self):
+        return self._get('course.canvasCourseId')
+
+    @property
+    def canvas_course_sections(self):
+        return self._get('canvasCourseSections')
+
+    @property
+    def id(self):  # noqa: A003
+        return self.get_id()
 
     @property
     def is_active(self):
-        return self.is_authenticated
+        return self._get('isAuthenticated')
 
     @property
     def is_admin(self):
-        return is_admin(self)
+        return self._get('isAdmin')
 
     @property
     def is_observer(self):
-        return is_observer(self)
+        return self._get('isObserver')
 
     @property
     def is_student(self):
-        return is_student(self)
+        return self._get('isStudent')
 
     @property
     def is_authenticated(self):
-        return self.user is not None
+        return self._get('isAuthenticated')
 
     @property
     def is_teaching(self):
-        return is_teaching(self)
+        return self._get('isTeaching')
 
     @property
-    def user_id(self):
-        return self.user and self.user.id
+    def protect_assets_per_section(self):
+        return self.is_student and self._get('course.protectsAssetsPerSection')
 
-    def logout(self):
-        self.user = None
+    def refresh(self):
+        user = User.find_by_id(self.user_id) if self.user_id else None
+        self.api_json = _construct_api_json(user)
 
     def to_api_json(self):
-        return {
-            **(self.user.to_api_json(include_points=True, include_sharing=True) if self.user else {}),
-            **{
-                'course': self.course and self.course.to_api_json(),
-                'isAdmin': self.is_admin,
-                'isAuthenticated': self.is_authenticated,
-                'isObserver': self.is_observer,
-                'isStudent': self.is_student,
-                'isTeaching': self.is_teaching,
-            },
-        }
+        return self.api_json
+
+    def _get(self, nested_property_reference):
+        if nested_property_reference in [
+            'assets',
+            'canvasGroups',
+            'course',
+            'course.active',
+            'course.canvasGroups'
+            'course.protectsAssetsPerSection',
+            'lastActivity',
+            'lookingForCollaborators',
+            'points',
+            'sharePoints',
+            'updatedAt',
+            'whiteboards',
+        ]:
+            raise ValueError(f'Referencing {nested_property_reference} (volatile data) in session object not allowed.')
+        value = None
+        keys = nested_property_reference.split('.')
+        for index, key in enumerate(keys):
+            if index == 0:
+                value = self.api_json.get(key)
+            elif isinstance(value, dict):
+                value = value.get(key)
+            else:
+                raise ValueError(f'Non-dict object in current_user.{nested_property_reference}')
+        return value
+
+    def _logout(self):
+        self.api_json = _construct_api_json()
+
+
+def _construct_api_json(user=None):
+    is_authenticated = user and (is_admin(user) or user.canvas_enrollment_state != 'inactive')
+    api_json = {
+        **(user.to_api_json(include_points=True, include_sharing=True) if is_authenticated else {}),
+        **{
+            'course': is_authenticated and user.course.to_api_json(),
+            'isAdmin': is_authenticated and is_admin(user),
+            'isAuthenticated': is_authenticated,
+            'isObserver': is_authenticated and is_observer(user),
+            'isStudent': is_authenticated and is_student(user),
+            'isTeaching': is_authenticated and is_teaching(user),
+        },
+    }
+    return api_json

--- a/squiggy/models/course.py
+++ b/squiggy/models/course.py
@@ -24,6 +24,7 @@ ENHANCEMENTS, OR MODIFICATIONS.
 """
 
 from dateutil.tz import tzutc
+from sqlalchemy.sql import text
 from squiggy import db, std_commit
 from squiggy.models.base import Base
 from squiggy.models.canvas import Canvas
@@ -131,6 +132,22 @@ class Course(Base):
         db.session.add(course)
         std_commit()
         return course
+
+    @classmethod
+    def is_user_in_course(cls, canvas_api_domain, canvas_course_id, user_id):
+        sql = """
+            SELECT u.id
+            FROM users u
+            JOIN courses c ON c.id = u.course_id
+            WHERE u.id = :user_id AND c.canvas_api_domain = :canvas_api_domain AND c.canvas_course_id = :canvas_course_id
+        """
+        args = {
+            'canvas_api_domain': canvas_api_domain,
+            'canvas_course_id': canvas_course_id,
+            'user_id': user_id,
+        }
+        result = db.session.execute(text(sql), args).first()
+        return bool(len(result or []))
 
     @classmethod
     def update(

--- a/tests/test_api/test_whiteboard_controller.py
+++ b/tests/test_api/test_whiteboard_controller.py
@@ -69,7 +69,11 @@ class TestGetWhiteboard:
         std_commit(allow_test_environment=True)
 
         fake_auth.login(student.id)
-        assert Whiteboard.find_by_id(LoginSession(student.id), whiteboard_id)['deletedAt']
+        whiteboard = Whiteboard.find_by_id(
+            current_user=LoginSession(student.id),
+            whiteboard_id=whiteboard_id,
+        )
+        assert whiteboard['deletedAt']
         _api_get_whiteboard(client, expected_status_code=404, whiteboard_id=whiteboard_id)
 
     def test_owner_view_whiteboard(self, client, fake_auth, mock_whiteboard):
@@ -440,11 +444,11 @@ class TestGetEligibleCollaborators:
     def test_authorized(self, client, fake_auth, authorized_user_id):
         """Authorized user can get /students_by_section."""
         fake_auth.login(authorized_user_id)
-        current_user = User.find_by_id(authorized_user_id)
         eligible_collaborators = self._api_eligible_collaborators(client)
         user_count = len(eligible_collaborators)
         assert user_count > 1
-        users_of_all_types = User.get_users_by_course_id(course_id=current_user.course.id)
+        user = User.find_by_id(authorized_user_id)
+        users_of_all_types = User.get_users_by_course_id(course_id=user.course.id)
         assert user_count == len(users_of_all_types)
 
     def test_course_all_users(self, client, fake_auth, mock_asset_course):


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2016

The `LoginSession` class was (1) holding on to an active db session, and (2) providing utility methods – eg, `update_looking_for_collaborators` – which kinda violates the intention of a read-only session object.  Furthermore, you can no longer use a `LoginSession` object to reference volatile user data (eg, assets); an error is raised if you attempt to reference such volatile attributes.  All in all, this should give us a more reliable and easy to use session object.