### PR TITLE
COL-2120, /whiteboard: take asset tiles out of the DOM when AddExistingAssets modal is closed

### DIFF
--- a/src/components/whiteboards/toolbar/assets/AddExistingAssets.vue
+++ b/src/components/whiteboards/toolbar/assets/AddExistingAssets.vue
@@ -25,7 +25,7 @@
         <span>{{ tooltipText }}</span>
       </v-tooltip>
     </template>
-    <v-card>
+    <v-card v-if="dialog">
       <v-card-title class="pb-1">
         <h2 id="modal-header" class="title">Select Asset(s)</h2>
       </v-card-title>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2120

Thank you Teena for inspecting the DOM.