### PR TITLE
COL-2126, the SyncDisabled component was relying on discarded currentUser attributes

### DIFF
--- a/squiggy/api/course_controller.py
+++ b/squiggy/api/course_controller.py
@@ -35,7 +35,7 @@ from squiggy.models.course import Course
 def activate():
     course = Course.find_by_id(current_user.course_id)
     course.activate()
-    return tolerant_jsonify({'status': 'success'})
+    return tolerant_jsonify(course.to_api_json(include_users=True))
 
 
 @app.route('/api/course/<course_id>')

--- a/src/components/util/SyncDisabled.vue
+++ b/src/components/util/SyncDisabled.vue
@@ -1,7 +1,7 @@
 <template>
-  <div>
+  <div v-if="course">
     <v-alert
-      v-if="!$currentUser.course.active"
+      v-if="!course.active"
       role="alert"
       outlined
       color="deep-orange darken-4"
@@ -51,19 +51,26 @@
 <script>
 import Context from '@/mixins/Context'
 import Utils from '@/mixins/Utils'
-import {activate} from '@/api/courses'
+import {activate, getCourse} from '@/api/courses'
 
 export default {
   name: 'SyncDisabled',
   mixins: [Context, Utils],
   data: () => ({
     activating: false,
+    course: undefined,
     reactivated: false
   }),
+  created() {
+    getCourse(this.$currentUser.courseId).then(data => {
+      this.course = data
+    })
+  },
   methods: {
     reactivateCourse() {
       this.activating = true
-      activate().then(() => {
+      activate().then(data => {
+        this.course = data
         this.$currentUser.course.active = true
         this.activating = false
         this.reactivated = true


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2126

We do not want to carry volatile course metadata in the current-user object, which is cached.