### PR TITLE
COL-2128, session user object must include 'supportsCustomMessaging'

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,7 @@ Vue.prototype.$isBookmarklet = isBookmarklet
 
 axios.get(`${apiBaseUrl}/api/profile/my`).then(data => {
   Vue.prototype.$currentUser = data
-  Vue.prototype.$supportsCustomMessaging = _.get(Vue.prototype.$currentUser, 'course.canvas.supportsCustomMessaging')
+  Vue.prototype.$supportsCustomMessaging = Vue.prototype.$currentUser.supportsCustomMessaging
 
   const mount = () => {
     axios.get(`${apiBaseUrl}/api/config`).then(data => {


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2128

And minor code cleanup: if not `is_authenticated` then return `None` not `False` when, for example, assetLibraryUrl.