### PR TITLE
COL-2135, if you use Vue.extend then you must explicitly ref 'router'

### DIFF
--- a/src/components/impactstudio/ActivityTimeline.vue
+++ b/src/components/impactstudio/ActivityTimeline.vue
@@ -79,6 +79,7 @@
 
 <script>
 import ActivityTimelineEventDetails from '@/components/impactstudio/ActivityTimelineEventDetails'
+import router from '@/router'
 import Vue from 'vue'
 
 const ActivityTimelineEventDetailsComponent = Vue.extend(ActivityTimelineEventDetails)
@@ -349,7 +350,8 @@ export default {
 
       eventDetails.append(() => {
         const eventDetailsComponent = new ActivityTimelineEventDetailsComponent({
-          propsData: displayProperties
+          propsData: displayProperties,
+          router
         })
         eventDetailsComponent.$mount()
         return eventDetailsComponent.$el

--- a/src/components/impactstudio/ActivityTimelineEventDetails.vue
+++ b/src/components/impactstudio/ActivityTimelineEventDetails.vue
@@ -19,13 +19,13 @@
     </div>
     <div class="text-truncate">
       <h3 class="event-details-popover-title">
-        <a
+        <router-link
           :id="`event-details-popover-${activityId}-asset-link`"
           class="d-block text-truncate"
-          :href="assetUrl"
+          :to="`/asset/${asset.id}?from=impactStudio`"
         >
           {{ title }}
-        </a>
+        </router-link>
       </h3>
       <p class="event-details-popover-description text-wrap">
         <a :id="`event-details-popover-${activityId}-profile-link`" :href="`/impact_studio/profile/${user.id}`">{{ user.name }}</a>


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2135

The unorthodox bit: `const ActivityTimelineEventDetailsComponent = Vue.extend(ActivityTimelineEventDetails)`