### PR TITLE
COL-1819, pull_prod_data now grabs courses.last_polled so Nagios doesn't freak out

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,7 +20,7 @@ config/*.pickle
 .env.*.local
 
 # Scripts
-scripts/*_local.sh
+scripts/**/*_local.sh
 scripts/db/local
 scripts/hasenpfeffer_incorporated/local
 scripts/node_js/save_whiteboard_as_png.js

--- a/scripts/hasenpfeffer_incorporated/README.md
+++ b/scripts/hasenpfeffer_incorporated/README.md
@@ -67,4 +67,6 @@ These entries allow you to connect to databases via ssh tunnel. For example:
 
    ![Elastic Beanstalk console](../../src/assets/hasenpfeffer_restart_app_server.jpg)
 
-7. Finally, you should verify that test environment has the data.
+7. Finally, verify that _/api/ping_ is happy and that the targeted test environment has a clone of prod data.
+
+Cheerio, mate!

--- a/scripts/hasenpfeffer_incorporated/pull_prod_data.sh
+++ b/scripts/hasenpfeffer_incorporated/pull_prod_data.sh
@@ -182,7 +182,8 @@ if [[ "${replacement_canvas}" ]]; then
                 replace(c.engagement_index_url, '${source_canvas}', '${replacement_canvas}') as engagement_index_url,
                 replace(c.whiteboards_url, '${source_canvas}', '${replacement_canvas}') as whiteboards_url,
                 '${replacement_canvas}' as canvas_api_domain,
-                c.active, c.created_at, c.updated_at, c.enable_daily_notifications, c.enable_weekly_notifications
+                c.active, c.created_at, c.updated_at, c.enable_daily_notifications, c.enable_weekly_notifications,
+                c.last_polled
               FROM courses c
               WHERE c.canvas_api_domain = '${source_canvas}'"
 


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-1819

Squiggy's `/api/ping` endpoint relies on at least one course having non-null `last_polled` value.  If no such course is found then Nagios complains.