### PR TITLE
Revert "COL-2217 Updates for python 3.11"

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: python
-# 3.9 is the most recent Python currently available for Travis.
-python: "3.9"
+python: "3.8"
 
 addons:
   postgresql: "12"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Providing LTI tools (Asset Library, Engagement Index, Whiteboards and Impact Stu
 
 ## Installation
 
-* Install Python 3.11
+* Install Python 3.7
 * Create your virtual environment (venv)
 * Install dependencies
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,12 @@ boto3==1.20.24
 canvasapi==3.0.0
 cryptography==38.0.1
 decorator==5.1.1
-dnspython==2.2.0
-eventlet==0.34.2
+eventlet==0.30.2
 Flask-Login==0.6.2
 Flask-SocketIO==5.3.2
 Flask-SQLAlchemy==3.0.3
 Flask==2.2.2
-gunicorn==21.2.0
+gunicorn==20.1.0
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.5


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2217

The front-end build is now broken and I'm not sure if the Python 3.11 update or something else is responsible.

This reverts commit 2cd3d694da8a9db1196e5d6cebb7faa548003116.

