### PR TITLE
COL-2217, revert to Python 3.7 and previous 00_ami.config (roll forward)

### DIFF
--- a/.ebextensions/00_ami.config
+++ b/.ebextensions/00_ami.config
@@ -3,12 +3,17 @@
 #
 packages:
   yum:
-    amazon-cloudwatch-agent: []
+    awslogs: []
     gcc-c++: []
     git: []
     mod_ssl: []
-    file-magic: []
-    postgresql15: []
+    python-magic: []
+
+commands:
+  01_postgres_activate:
+    command: sudo amazon-linux-extras enable postgresql14
+  02_postgres_install:
+    command: sudo yum install -y postgresql
 
 option_settings:
   aws:elasticbeanstalk:cloudwatch:logs:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 sudo: required
 language: python
-# 3.9 is the most recent Python currently available for Travis.
-python: "3.9"
+python: "3.8"
 
 addons:
   postgresql: "12"

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Providing LTI tools (Asset Library, Engagement Index, Whiteboards and Impact Stu
 
 ## Installation
 
-* Install Python 3.11
+* Install Python 3.7
 * Create your virtual environment (venv)
 * Install dependencies
 

--- a/buildspec.yml
+++ b/buildspec.yml
@@ -4,7 +4,7 @@ phases:
   install:
     runtime-versions:
       nodejs: 16
-      python: 3.9
+      python: 3.7
     commands:
       - echo -e '@neverendingsupport:registry=https://registry.nes.herodevs.com/npm/pkg/\n//registry.nes.herodevs.com/npm/pkg/:_authToken="'${NES_AUTH_TOKEN}'"' > .npmrc
       - npm -v

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,13 +2,12 @@ boto3==1.20.24
 canvasapi==3.0.0
 cryptography==38.0.1
 decorator==5.1.1
-dnspython==2.2.0
-eventlet==0.34.2
+eventlet==0.30.2
 Flask-Login==0.6.2
 Flask-SocketIO==5.3.2
 Flask-SQLAlchemy==3.0.3
 Flask==2.2.2
-gunicorn==21.2.0
+gunicorn==20.1.0
 lti==0.9.5
 oauthlib==3.1.1
 psycopg2-binary==2.9.5


### PR DESCRIPTION
https://jira-secure.berkeley.edu/browse/COL-2217

These were manually cherry-picked from recent commits. I was careful not to revert the `neverendingsupport/vue2` stuff. @felder should review.